### PR TITLE
Use non-blocking IO with /dev/random.

### DIFF
--- a/Crypto/Random/Entropy/Unix.hs
+++ b/Crypto/Random/Entropy/Unix.hs
@@ -31,7 +31,7 @@ newtype DevURandom = DevURandom DeviceName
 instance EntropySource DevRandom where
     entropyOpen = fmap DevRandom `fmap` testOpen "/dev/random"
     entropyGather (DevRandom name) ptr n =
-        withDev name $ \h -> gatherDevEntropy h ptr n
+        withDev name $ \h -> gatherDevEntropyNonBlock h ptr n
     entropyClose (DevRandom _)  = return ()
 
 instance EntropySource DevURandom where
@@ -66,4 +66,9 @@ closeDev h = hClose h
 gatherDevEntropy :: H -> Ptr Word8 -> Int -> IO Int
 gatherDevEntropy h ptr sz =
      (fromIntegral `fmap` hGetBufSome h ptr (fromIntegral sz))
+    `E.catch` \(_ :: IOException) -> return 0
+
+gatherDevEntropyNonBlock :: H -> Ptr Word8 -> Int -> IO Int
+gatherDevEntropyNonBlock h ptr sz =
+     (fromIntegral `fmap` hGetBufNonBlocking h ptr (fromIntegral sz))
     `E.catch` \(_ :: IOException) -> return 0


### PR DESCRIPTION
I'm adding Network.TLS as HTTPS provider to happstack and run into the problem on Linux VM in Azure. First request is served instantly, but every next one is blocked for up to 20 seconds. Quick scan with strace showed that process is waiting for at least one byte to be available from the /dev/random.
This is quick hack to skip /dev/random if it is not ready. I also wonder if it is expected for entropy pool to be refreshed on every handshake, it would hurt the performance.
