### PR TITLE
Document the arguments for DH.generateParams

### DIFF
--- a/Crypto/Number/Serialize.hs
+++ b/Crypto/Number/Serialize.hs
@@ -33,8 +33,8 @@ i2osp m = B.allocAndFreeze sz (\p -> Internal.i2osp m p sz >> return ())
         !sz = numBytes m
 
 -- | just like i2osp, but take an extra parameter for size.
--- if the number is too big to fit in @len bytes, nothing is returned
--- otherwise the number is padded with 0 to fit the @len required.
+-- if the number is too big to fit in @len@ bytes, 'Nothing' is returned
+-- otherwise the number is padded with 0 to fit the @len@ required.
 i2ospOf :: B.ByteArray ba => Int -> Integer -> Maybe ba
 i2ospOf len m
     | len <= 0  = Nothing

--- a/Crypto/PubKey/DH.hs
+++ b/Crypto/PubKey/DH.hs
@@ -46,7 +46,10 @@ newtype SharedKey = SharedKey Integer
 
 -- | generate params from a specific generator (2 or 5 are common values)
 -- we generate a safe prime (a prime number of the form 2p+1 where p is also prime)
-generateParams :: MonadRandom m => Int -> Integer -> m Params
+generateParams :: MonadRandom m =>
+                  Int                   -- ^ number of bits
+               -> Integer               -- ^ generator
+               -> m Params
 generateParams bits generator =
     (\p -> Params p generator) <$> generateSafePrime bits
 


### PR DESCRIPTION
Document the arguments for `DH.generateParams` and also fix the formatting in the docs of `Serialize.i2ospOf`.
