### PR TITLE
Add support_blake2 flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10
+
+* Add support_blake2 flag
+
 ## 0.9
 
 * Quiet down unused module imports

--- a/Crypto/Hash/Algorithms.hs
+++ b/Crypto/Hash/Algorithms.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : Crypto.Hash.Algorithms
 -- License     : BSD-style
@@ -10,10 +11,12 @@
 module Crypto.Hash.Algorithms
     ( HashAlgorithm
     -- * hash algorithms
+#ifdef SUPPORT_BLAKE2
     , Blake2s_256(..)
     , Blake2sp_256(..)
     , Blake2b_512(..)
     , Blake2bp_512(..)
+#endif
     , MD2(..)
     , MD4(..)
     , MD5(..)
@@ -44,10 +47,12 @@ module Crypto.Hash.Algorithms
     ) where
 
 import           Crypto.Hash.Types (HashAlgorithm)
+#ifdef SUPPORT_BLAKE2
 import           Crypto.Hash.Blake2s
 import           Crypto.Hash.Blake2sp
 import           Crypto.Hash.Blake2b
 import           Crypto.Hash.Blake2bp
+#endif
 import           Crypto.Hash.MD2
 import           Crypto.Hash.MD4
 import           Crypto.Hash.MD5

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -63,6 +63,11 @@ Flag support_pclmuldq
   Default:           False
   Manual:            True
 
+Flag support_blake2
+  Description:       Allow compilation of Blake2 hash algorithms
+  Default:           True
+  Manual:            True
+
 Flag integer-gmp
   Description:       Whether or not to use GMP for some functions
   Default:           True
@@ -149,10 +154,6 @@ Library
                      Crypto.Hash.MD2
                      Crypto.Hash.MD4
                      Crypto.Hash.MD5
-                     Crypto.Hash.Blake2s
-                     Crypto.Hash.Blake2sp
-                     Crypto.Hash.Blake2b
-                     Crypto.Hash.Blake2bp
                      Crypto.Hash.RIPEMD160
                      Crypto.Hash.Skein256
                      Crypto.Hash.Skein512
@@ -199,10 +200,6 @@ Library
                    , cbits/cryptonite_md2.c
                    , cbits/cryptonite_md4.c
                    , cbits/cryptonite_md5.c
-                   , cbits/cryptonite_blake2s.c
-                   , cbits/cryptonite_blake2sp.c
-                   , cbits/cryptonite_blake2b.c
-                   , cbits/cryptonite_blake2bp.c
                    , cbits/cryptonite_ripemd.c
                    , cbits/cryptonite_skein256.c
                    , cbits/cryptonite_skein512.c
@@ -210,10 +207,6 @@ Library
                    , cbits/cryptonite_whirlpool.c
                    , cbits/cryptonite_scrypt.c
                    , cbits/cryptonite_sysrand.c
-                   , cbits/blake2/blake2s.c
-                   , cbits/blake2/blake2sp.c
-                   , cbits/blake2/blake2b.c
-                   , cbits/blake2/blake2bp.c
   include-dirs:  cbits cbits/ed25519 cbits/blake2
 
   -- FIXME armel or mispel is also little endian.
@@ -236,6 +229,21 @@ Library
     if flag(support_pclmuldq)
        CC-options:  -msse4.1 -mpclmul -DWITH_PCLMUL
     C-sources:      cbits/aes/x86ni.c
+
+  if flag(support_blake2)
+    CPP-options:    -DSUPPORT_BLAKE2
+    C-sources:      cbits/cryptonite_blake2s.c
+                  , cbits/cryptonite_blake2sp.c
+                  , cbits/cryptonite_blake2b.c
+                  , cbits/cryptonite_blake2bp.c
+                  , cbits/blake2/blake2s.c
+                  , cbits/blake2/blake2sp.c
+                  , cbits/blake2/blake2b.c
+                  , cbits/blake2/blake2bp.c
+    Other-modules:  Crypto.Hash.Blake2s
+                    Crypto.Hash.Blake2sp
+                    Crypto.Hash.Blake2b
+                    Crypto.Hash.Blake2bp
 
   if os(windows)
     cpp-options:    -DWINDOWS


### PR DESCRIPTION
Blake2 does not compile on arm.

Adding this flag makes it possible to compile this library on arm arch and by extension makes it possible to compile and run Yesod apps on arm systems.
