### PR TITLE
Adding miyaguchi-preneel hash construction

### DIFF
--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -10,7 +10,7 @@
 --
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Crypto.ConstructHash.MiyaguchiPreneel
-       ( mp, mp'
+       ( compute, compute'
        , MiyaguchiPreneel
        ) where
 
@@ -30,11 +30,11 @@ instance Eq (MiyaguchiPreneel a) where
 
 
 -- | Compute Miyaguchi-Preneel one way compress using the supplied block cipher.
-mp' :: (ByteArrayAccess bin, BlockCipher cipher)
-    => (Bytes -> cipher)       -- ^ key build function to compute Miyaguchi-Preneel. care about block-size and key-size
-    -> bin                     -- ^ input message
-    -> MiyaguchiPreneel cipher -- ^ output tag
-mp' g = MP . foldl' (step $ g) (B.replicate bsz 0) . chunks . B.convert
+compute' :: (ByteArrayAccess bin, BlockCipher cipher)
+         => (Bytes -> cipher)       -- ^ key build function to compute Miyaguchi-Preneel. care about block-size and key-size
+         -> bin                     -- ^ input message
+         -> MiyaguchiPreneel cipher -- ^ output tag
+compute' g = MP . foldl' (step $ g) (B.replicate bsz 0) . chunks . B.convert
   where
     bsz = blockSize ( g B.empty {- dummy to get block size -} )
     chunks msg
@@ -47,10 +47,10 @@ mp' g = MP . foldl' (step $ g) (B.replicate bsz 0) . chunks . B.convert
 --   Only safe when KEY-SIZE equals to BLOCK-SIZE.
 --
 --   Simple usage /mp' msg :: MiyaguchiPreneel AES128/
-mp :: (ByteArrayAccess bin, BlockCipher cipher)
-   => bin                     -- ^ input message
-   -> MiyaguchiPreneel cipher -- ^ output tag
-mp = mp' $ throwCryptoError . cipherInit
+compute :: (ByteArrayAccess bin, BlockCipher cipher)
+        => bin                     -- ^ input message
+        -> MiyaguchiPreneel cipher -- ^ output tag
+compute = compute' $ throwCryptoError . cipherInit
 
 -- | computation step of Miyaguchi-Preneel
 step :: (ByteArray ba, BlockCipher k)

--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -1,0 +1,56 @@
+-- |
+-- Module      : Crypto.ConstructHash.MiyaguchiPreneel
+-- License     : BSD-style
+-- Maintainer  : Kei Hibino <ex8k.hibino@gmail.com>
+-- Stability   : experimental
+-- Portability : unknown
+--
+-- provide the hash function construction method from block cipher
+-- <https://en.wikipedia.org/wiki/One-way_compression_function>
+--
+module Crypto.ConstructHash.MiyaguchiPreneel ( mp, cipherInit' ) where
+
+import           Data.List (foldl')
+
+import           Crypto.Cipher.Types
+import           Crypto.Error (eitherCryptoError)
+import           Crypto.Internal.ByteArray (ByteArrayAccess, ByteArray)
+import qualified Crypto.Internal.ByteArray as B
+
+
+-- | Compute Miyaguchi-Preneel one way compress using the supplied block cipher.
+--   Simple usage /mp (cipherInit' :: ByteString -> AES128) msg/
+mp :: (ByteArrayAccess bin, ByteArray bout, ByteArray ba, BlockCipher cipher)
+   => (ba -> cipher) -- ^ key build function to compute Miyaguchi-Preneel
+   -> bin            -- ^ input message
+   -> bout           -- ^ output tag
+mp g = B.convert . foldl' (step g) (B.replicate bsz 0) . chunks . B.convert
+  where
+    bsz = blockSize ( g B.empty {- dummy to get block size -} )
+    chunks msg
+      | B.null tl  =  [hd]
+      | otherwise  =   hd : chunks tl
+      where
+        (hd, tl) = B.splitAt bsz msg
+
+-- | Simple key build function, which may raise size error.
+cipherInit' :: (ByteArray ba, Cipher k) => ba -> k
+cipherInit' = either (error . show) id . eitherCryptoError . cipherInit
+
+-- | computation step of Miyaguchi-Preneel
+step :: (ByteArray ba, BlockCipher k)
+     => (ba -> k)
+     -> ba
+     -> ba
+     -> ba
+step g iv msg =
+    ecbEncrypt k pmsg `bxor` iv `bxor` pmsg
+  where
+    k = g iv
+    pmsg = pad0 k msg
+
+pad0 :: (ByteArray ba, BlockCipher k) => k -> ba -> ba
+pad0 k s = s `B.append` B.replicate (blockSize k - B.length s) 0
+
+bxor :: ByteArray ba => ba -> ba -> ba
+bxor = B.xor

--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -14,7 +14,7 @@ import           Data.List (foldl')
 
 import           Crypto.Cipher.Types
 import           Crypto.Error (eitherCryptoError)
-import           Crypto.Internal.ByteArray (ByteArrayAccess, ByteArray)
+import           Crypto.Internal.ByteArray (ByteArrayAccess, ByteArray, Bytes)
 import qualified Crypto.Internal.ByteArray as B
 
 
@@ -24,11 +24,11 @@ mp :: (ByteArrayAccess bin, ByteArray bout, ByteArray ba, BlockCipher cipher)
    => (ba -> cipher) -- ^ key build function to compute Miyaguchi-Preneel
    -> bin            -- ^ input message
    -> bout           -- ^ output tag
-mp g = B.convert . foldl' (step g) (B.replicate bsz 0) . chunks . B.convert
+mp g = B.convert . foldl' (step $ g . B.convert) (B.replicate bsz 0) . chunks . B.convert
   where
     bsz = blockSize ( g B.empty {- dummy to get block size -} )
     chunks msg
-      | B.null tl  =  [hd]
+      | B.null tl  =  [hd :: Bytes]
       | otherwise  =   hd : chunks tl
       where
         (hd, tl) = B.splitAt bsz msg

--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Crypto.ConstructHash.MiyaguchiPreneel
        ( mp, mp'
-       , MiyaguchiPreneel(..)
+       , MiyaguchiPreneel
        , cipherInit'
        ) where
 

--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -23,8 +23,8 @@ import           Crypto.Internal.ByteArray (ByteArrayAccess, ByteArray, Bytes)
 import qualified Crypto.Internal.ByteArray as B
 
 
-newtype MiyaguchiPreneel a = MP { chashGetBytes :: Bytes }
-    deriving ByteArrayAccess
+newtype MiyaguchiPreneel a = MP Bytes
+    deriving (ByteArrayAccess)
 
 instance Eq (MiyaguchiPreneel a) where
     MP b1 == MP b2  =  B.constEq b1 b2

--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -12,13 +12,12 @@
 module Crypto.ConstructHash.MiyaguchiPreneel
        ( mp, mp'
        , MiyaguchiPreneel
-       , cipherInit'
        ) where
 
 import           Data.List (foldl')
 
 import           Crypto.Cipher.Types
-import           Crypto.Error (eitherCryptoError)
+import           Crypto.Error (throwCryptoError)
 import           Crypto.Internal.ByteArray (ByteArrayAccess, ByteArray, Bytes)
 import qualified Crypto.Internal.ByteArray as B
 
@@ -44,10 +43,6 @@ mp' g = MP . foldl' (step $ g) (B.replicate bsz 0) . chunks . B.convert
       where
         (hd, tl) = B.splitAt bsz msg
 
--- | Simple key build function, which may raise size error.
-cipherInit' :: (ByteArray ba, Cipher k) => ba -> k
-cipherInit' = either (error . show) id . eitherCryptoError . cipherInit
-
 -- | Compute Miyaguchi-Preneel one way compress using the infered block cipher.
 --   Only safe when KEY-SIZE equals to BLOCK-SIZE.
 --
@@ -55,7 +50,7 @@ cipherInit' = either (error . show) id . eitherCryptoError . cipherInit
 mp :: (ByteArrayAccess bin, BlockCipher cipher)
    => bin                     -- ^ input message
    -> MiyaguchiPreneel cipher -- ^ output tag
-mp = mp' cipherInit'
+mp = mp' $ throwCryptoError . cipherInit
 
 -- | computation step of Miyaguchi-Preneel
 step :: (ByteArray ba, BlockCipher k)

--- a/Crypto/Data/Padding.hs
+++ b/Crypto/Data/Padding.hs
@@ -56,4 +56,10 @@ unpad (PKCS7 sz) bin
     paddingSz   = fromIntegral paddingByte
     (content, padding) = B.splitAt (len - paddingSz) bin
     paddingWitness     = B.replicate paddingSz paddingByte :: Bytes
-unpad (ZERO sz)  bin = Nothing
+unpad (ZERO sz)  bin
+    | len == 0                           = Nothing
+    | (len `mod` sz) /= 0                = Nothing
+    | B.index bin (len - 1) /= 0         = Just bin
+    | otherwise                          = Nothing
+  where
+    len         = B.length bin

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -97,6 +97,7 @@ Library
                      Crypto.Cipher.Salsa
                      Crypto.Cipher.TripleDES
                      Crypto.Cipher.Types
+                     Crypto.ConstructHash.MiyaguchiPreneel
                      Crypto.Data.AFIS
                      Crypto.Data.Padding
                      Crypto.Error

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -307,6 +307,7 @@ Test-Suite test-cryptonite
                      KAT_Ed25519
                      KAT_CMAC
                      KAT_HMAC
+                     KAT_MiyaguchiPreneel
                      KAT_PBKDF2
                      KAT_PubKey.DSA
                      KAT_PubKey.ECC

--- a/tests/KAT_MiyaguchiPreneel.hs
+++ b/tests/KAT_MiyaguchiPreneel.hs
@@ -7,25 +7,22 @@ import           Crypto.ConstructHash.MiyaguchiPreneel
 import           Imports
 
 import           Data.Char (digitToInt)
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteArray as B
+import Data.ByteArray.Encoding (Base (Base16), convertFromBase)
 
 
 runMP128 :: ByteString -> ByteString
 runMP128 s = B.convert (mp s :: MiyaguchiPreneel AES128)
 
 hxs :: String -> ByteString
-hxs = BS.pack . rec' where
-    dtoW8 = fromIntegral . digitToInt
-    rec' (' ':xs)  =  rec' xs
-    rec' (x:y:xs)  =  dtoW8 x * 16 + dtoW8 y : rec' xs
-    rec' [_]       =  error "hxs: invalid hex pattern."
-    rec' []        =  []
+hxs = either (error . ("hxs:" ++)) id . convertFromBase Base16
+      . B8.pack . filter (/= ' ')
 
 gAES128 :: TestTree
 gAES128 =
   igroup "aes128"
-  [ runMP128  BS.empty
+  [ runMP128  B8.empty
     @?=       hxs "66e94bd4 ef8a2c3b 884cfa59 ca342b2e"
   , runMP128 (hxs "01000000 00000000 00000000 00000000")
     @?=       hxs "46711816 e91d6ff0 59bbbf2b f58e0fd3"

--- a/tests/KAT_MiyaguchiPreneel.hs
+++ b/tests/KAT_MiyaguchiPreneel.hs
@@ -2,7 +2,7 @@
 module KAT_MiyaguchiPreneel (tests) where
 
 import           Crypto.Cipher.AES (AES128)
-import           Crypto.ConstructHash.MiyaguchiPreneel
+import           Crypto.ConstructHash.MiyaguchiPreneel as MiyaguchiPreneel
 
 import           Imports
 
@@ -13,7 +13,7 @@ import Data.ByteArray.Encoding (Base (Base16), convertFromBase)
 
 
 runMP128 :: ByteString -> ByteString
-runMP128 s = B.convert (mp s :: MiyaguchiPreneel AES128)
+runMP128 s = B.convert (MiyaguchiPreneel.compute s :: MiyaguchiPreneel AES128)
 
 hxs :: String -> ByteString
 hxs = either (error . ("hxs:" ++)) id . convertFromBase Base16

--- a/tests/KAT_MiyaguchiPreneel.hs
+++ b/tests/KAT_MiyaguchiPreneel.hs
@@ -8,10 +8,11 @@ import           Imports
 
 import           Data.Char (digitToInt)
 import qualified Data.ByteString as BS
+import qualified Data.ByteArray as B
 
 
 runMP128 :: ByteString -> ByteString
-runMP128 = mp (cipherInit' :: ByteString -> AES128)
+runMP128 s = B.convert $ mp (cipherInit' :: ByteString -> AES128) s
 
 hxs :: String -> ByteString
 hxs = BS.pack . rec' where

--- a/tests/KAT_MiyaguchiPreneel.hs
+++ b/tests/KAT_MiyaguchiPreneel.hs
@@ -1,0 +1,56 @@
+
+module KAT_MiyaguchiPreneel (tests) where
+
+import qualified Crypto.MAC.CMAC as CMAC
+import           Crypto.Cipher.Types (Cipher, cipherInit, BlockCipher, ecbEncrypt, blockSize)
+import           Crypto.Error (eitherCryptoError)
+import           Crypto.Cipher.AES (AES128, AES192, AES256)
+import           Crypto.Cipher.TripleDES (DES_EDE3, DES_EDE2)
+import           Crypto.ConstructHash.MiyaguchiPreneel
+
+import           Imports
+
+import           Data.Char (digitToInt)
+import qualified Data.ByteString as BS
+
+
+runMP128 :: ByteString -> ByteString
+runMP128 = mp (cipherInit' :: ByteString -> AES128)
+
+hxs :: String -> ByteString
+hxs = BS.pack . rec' where
+    dtoW8 = fromIntegral . digitToInt
+    rec' (' ':xs)  =  rec' xs
+    rec' (x:y:xs)  =  dtoW8 x * 16 + dtoW8 y : rec' xs
+    rec' [_]       =  error "hxs: invalid hex pattern."
+    rec' []        =  []
+
+gAES128 :: TestTree
+gAES128 =
+  igroup "aes128"
+  [ runMP128  BS.empty
+    @?=       hxs "66e94bd4 ef8a2c3b 884cfa59 ca342b2e"
+  , runMP128 (hxs "01000000 00000000 00000000 00000000")
+    @?=       hxs "46711816 e91d6ff0 59bbbf2b f58e0fd3"
+  , runMP128 (hxs "00000000 00000000 00000000 00000001")
+    @?=       hxs "58e2fcce fa7e3061 367f1d57 a4e7455b"
+  , runMP128     (hxs $
+                  "00000000 00000000 00000000 00000000" ++
+                  "01")
+    @?=       hxs "a5ff35ae 097adf5d 646abf5e bf4c16f4"
+  ]
+
+igroup :: TestName -> [Assertion] -> TestTree
+igroup nm = testGroup nm . zipWith (flip ($)) [1..] . map icase
+  where
+    icase c i = testCase (show (i :: Int)) c
+
+vectors :: TestTree
+vectors =
+  testGroup "KATs"
+  [ gAES128 ]
+
+tests :: TestTree
+tests =
+    testGroup "MiyaguchiPreneel"
+    [ vectors ]

--- a/tests/KAT_MiyaguchiPreneel.hs
+++ b/tests/KAT_MiyaguchiPreneel.hs
@@ -12,7 +12,7 @@ import qualified Data.ByteArray as B
 
 
 runMP128 :: ByteString -> ByteString
-runMP128 s = B.convert $ mp (cipherInit' :: ByteString -> AES128) s
+runMP128 s = B.convert (mp s :: MiyaguchiPreneel AES128)
 
 hxs :: String -> ByteString
 hxs = BS.pack . rec' where

--- a/tests/KAT_MiyaguchiPreneel.hs
+++ b/tests/KAT_MiyaguchiPreneel.hs
@@ -1,11 +1,7 @@
 
 module KAT_MiyaguchiPreneel (tests) where
 
-import qualified Crypto.MAC.CMAC as CMAC
-import           Crypto.Cipher.Types (Cipher, cipherInit, BlockCipher, ecbEncrypt, blockSize)
-import           Crypto.Error (eitherCryptoError)
-import           Crypto.Cipher.AES (AES128, AES192, AES256)
-import           Crypto.Cipher.TripleDES (DES_EDE3, DES_EDE2)
+import           Crypto.Cipher.AES (AES128)
 import           Crypto.ConstructHash.MiyaguchiPreneel
 
 import           Imports

--- a/tests/Padding.hs
+++ b/tests/Padding.hs
@@ -14,9 +14,9 @@ cases =
     ]
 
 zeroCases =
-    [ ("", 4, "\NUL\NUL\NUL\NUL")
-    , ("abcdef", 8, "abcdef\NUL\NUL")
-    , ("0123456789abcdef", 16, "0123456789abcdef")
+    [ ("", 4, "\NUL\NUL\NUL\NUL", Nothing)
+    , ("abcdef", 8, "abcdef\NUL\NUL", Nothing)
+    , ("0123456789abcdef", 16, "0123456789abcdef", Just "0123456789abcdef")
     ]
 
 --instance Arbitrary where
@@ -27,9 +27,11 @@ testPad n (inp, sz, padded) =
                                          , eqTest "unpadded" (Just inp) (unpad (PKCS7 sz) padded)
                                          ]
 
-testZeroPad :: Int -> (B.ByteString, Int, B.ByteString) -> TestTree
-testZeroPad n (inp, sz, padded) =
-    testCase (show n) $ propertyHoldCase [ eqTest "padded" padded (pad (ZERO sz) inp) ]
+testZeroPad :: Int -> (B.ByteString, Int, B.ByteString, Maybe B.ByteString) -> TestTree
+testZeroPad n (inp, sz, padded, unpadded) =
+    testCase (show n) $ propertyHoldCase [ eqTest "padded" padded (pad (ZERO sz) inp)
+                                         , eqTest "unpadded" unpadded (unpad (ZERO sz) padded)
+                                         ]
 
 tests = testGroup "Padding"
     [ testGroup "Cases" $ map (uncurry testPad) (zip [1..] cases)

--- a/tests/Padding.hs
+++ b/tests/Padding.hs
@@ -13,6 +13,12 @@ cases =
     , ("xyze", 5, "xyze\x01")
     ]
 
+zeroCases =
+    [ ("", 4, "\NUL\NUL\NUL\NUL")
+    , ("abcdef", 8, "abcdef\NUL\NUL")
+    , ("0123456789abcdef", 16, "0123456789abcdef")
+    ]
+
 --instance Arbitrary where
 
 testPad :: Int -> (B.ByteString, Int, B.ByteString) -> TestTree
@@ -21,6 +27,11 @@ testPad n (inp, sz, padded) =
                                          , eqTest "unpadded" (Just inp) (unpad (PKCS7 sz) padded)
                                          ]
 
+testZeroPad :: Int -> (B.ByteString, Int, B.ByteString) -> TestTree
+testZeroPad n (inp, sz, padded) =
+    testCase (show n) $ propertyHoldCase [ eqTest "padded" padded (pad (ZERO sz) inp) ]
+
 tests = testGroup "Padding"
     [ testGroup "Cases" $ map (uncurry testPad) (zip [1..] cases)
+    , testGroup "ZeroCases" $ map (uncurry testZeroPad) (zip [1..] zeroCases)
     ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -10,6 +10,7 @@ import qualified Poly1305
 import qualified Salsa
 import qualified ChaCha
 import qualified ChaChaPoly1305
+import qualified KAT_MiyaguchiPreneel
 import qualified KAT_CMAC
 import qualified KAT_HMAC
 import qualified KAT_HKDF
@@ -34,6 +35,9 @@ tests = testGroup "cryptonite"
     [ Number.tests
     , Hash.tests
     , Padding.tests
+    , testGroup "ConstructHash"
+        [ KAT_MiyaguchiPreneel.tests
+        ]
     , testGroup "MAC"
         [ Poly1305.tests
         , KAT_CMAC.tests


### PR DESCRIPTION
Hi.

I want miyaguchi-preneel hash construction
(known as one-way compression function
 https://en.wikipedia.org/wiki/One-way_compression_function#Miyaguchi.E2.80.93Preneel)
available with cryptonite block-cipher.

I implemented a naive implementation and test vectors.
