### PR TITLE
Arithmetic over F2m

### DIFF
--- a/Crypto/Number/F2m.hs
+++ b/Crypto/Number/F2m.hs
@@ -9,6 +9,7 @@
 -- not optimal and it doesn't provide protection against timing
 -- attacks. The 'm' parameter is implicitly derived from the irreducible
 -- polynomial where applicable.
+
 module Crypto.Number.F2m
     ( BinaryPolynomial
     , addF2m
@@ -22,88 +23,125 @@ module Crypto.Number.F2m
 
 import Data.Bits ((.&.),(.|.),xor,shift,testBit)
 import Crypto.Number.Basic
-import Crypto.Internal.Imports
 
 -- | Binary Polynomial represented by an integer
 type BinaryPolynomial = Integer
 
--- | Addition over F₂m. This is just a synonym of  'xor'.
-addF2m :: Integer -> Integer -> Integer
+-- | Addition over F₂m. This is just a synonym of 'xor'.
+addF2m :: Integer
+       -> Integer
+       -> Integer
 addF2m = xor
 {-# INLINE addF2m #-}
 
--- | Binary polynomial reduction modulo using long division algorithm.
-modF2m :: BinaryPolynomial -- ^ Irreducible binary polynomial
-       -> Integer -> Integer
-modF2m fx = go
-  where
-    lfx = log2 fx
-    go n | s == 0  = n `xor` fx
-         | s < 0 = n
-         | otherwise = go $ n `xor` shift fx s
+-- | Reduction by modulo over F₂m.
+--
+-- This function is undefined for negative arguments, because their bit
+-- representation is platform-dependent. Zero modulus is also prohibited.
+modF2m :: BinaryPolynomial -- ^ Modulus
+       -> Integer
+       -> Integer
+modF2m fx i
+    | fx < 0 || i < 0 = error "modF2m: negative number represent no binary polynomial"
+    | fx == 0         = error "modF2m: cannot divide by zero polynomial"
+    | fx == 1         = 0
+    | otherwise       = go i
       where
-        s = log2 n - lfx
+        lfx = log2 fx
+        go n | s == 0    = n `addF2m` fx
+             | s < 0     = n
+             | otherwise = go $ n `addF2m` shift fx s
+                where s = log2 n - lfx
 {-# INLINE modF2m #-}
 
 -- | Multiplication over F₂m.
 --
---     n1 * n2 (in F(2^m))
-mulF2m :: BinaryPolynomial  -- ^ Irreducible binary polynomial
-       -> Integer -> Integer -> Integer
-mulF2m fx n1 n2 = modF2m fx
-                $ go (if n2 `mod` 2 == 1 then n1 else 0) (log2 n2)
-  where
-    go n s | s == 0  = n
-           | otherwise = if testBit n2 s
-                            then go (n `xor` shift n1 s) (s - 1)
-                            else go n (s - 1)
+-- This function is undefined for negative arguments, because their bit
+-- representation is platform-dependent. Zero modulus is also prohibited.
+mulF2m :: BinaryPolynomial -- ^ Modulus
+       -> Integer
+       -> Integer
+       -> Integer
+mulF2m fx n1 n2
+    |    fx < 0
+      || n1 < 0
+      || n2 < 0 = error "mulF2m: negative number represent no binary binary polynomial"
+    | fx == 0   = error "modF2m: cannot multiply modulo zero polynomial"
+    | otherwise = modF2m fx $ go (if n2 `mod` 2 == 1 then n1 else 0) (log2 n2)
+      where
+        go n s | s == 0  = n
+               | otherwise = if testBit n2 s
+                                then go (n `addF2m` shift n1 s) (s - 1)
+                                else go n (s - 1)
 {-# INLINABLE mulF2m #-}
 
 -- | Squaring over F₂m.
+--
+-- This function is undefined for negative arguments, because their bit
+-- representation is platform-dependent. Zero modulus is also prohibited.
+--
 -- TODO: This is still slower than @mulF2m@.
-
+--
 -- Multiplication table? C?
-squareF2m :: BinaryPolynomial  -- ^ Irreducible binary polynomial
-          -> Integer -> Integer
+squareF2m :: BinaryPolynomial -- ^ Modulus
+          -> Integer
+          -> Integer
 squareF2m fx = modF2m fx . squareF2m'
 {-# INLINE squareF2m #-}
 
-squareF2m' :: Integer -> Integer
-squareF2m' n1 = go n1 ln1
-  where
-    ln1 = log2 n1
-    go n s | s == 0 = n
-           | otherwise = go (x .|. y) (s - 1)
+-- | Squaring over F₂m.
+--
+-- This function is undefined for negative arguments, because their bit
+-- representation is platform-dependent.
+squareF2m' :: Integer
+           -> Integer
+squareF2m' n1
+    | n1 < 0    = error "mulF2m: negative number represent no binary binary polynomial"
+    | otherwise = go n1 ln1
       where
-        x = shift (shift n (2 * (s - ln1) - 1)) (2 * (ln1 - s) + 2)
-        y = n .&. (shift 1 (2 * (ln1 - s) + 1) - 1)
+        ln1 = log2 n1
+        go n s | s == 0 = n
+               | otherwise = go (x .|. y) (s - 1)
+                  where
+                    x = shift (shift n (2 * (s - ln1) - 1)) (2 * (ln1 - s) + 2)
+                    y = n .&. (shift 1 (2 * (ln1 - s) + 1) - 1)
 {-# INLINE squareF2m' #-}
 
--- | Inversion of @n over F₂m using extended Euclidean algorithm.
+-- | Extended GCD algorithm for polynomials. For @a@ and @b@ returns @(g, u, v)@ such that @a * u + b * v == g@.
 --
--- If @n doesn't have an inverse, Nothing is returned.
-invF2m :: BinaryPolynomial -- ^ Irreducible binary polynomial
-       -> Integer -> Maybe Integer
-invF2m _  0 = Nothing
-invF2m fx n
-    | n >= fx   = Nothing
-    | otherwise = go n fx 1 0
-    where
-      go u v g1 g2
-          | u == 1    = Just $ modF2m fx g1
-          | j < 0     = go u  (v  `xor` shift  u (-j)) g1 (g2 `xor` shift g1 (-j))
-          | otherwise = go (u  `xor` shift v  j) v (g1 `xor` shift g2 j) g2
-        where
-          j = log2 u - log2 v
+-- Reference: https://en.wikipedia.org/wiki/Polynomial_greatest_common_divisor#B.C3.A9zout.27s_identity_and_extended_GCD_algorithm
+gcdF2m :: Integer
+       -> Integer
+       -> (Integer, Integer, Integer)
+gcdF2m a b = go (a, b, 1, 0, 0, 1)
+  where
+    go (g, 0, u, _, v, _)
+        = (g, u, v)
+    go (r0, r1, s0, s1, t0, t1)
+        = go (r1, r0 `addF2m` shift r1 j, s1, s0 `addF2m` shift s1 j, t1, t0 `addF2m` shift t1 j)
+            where j = max 0 (log2 r0 - log2 r1)
+
+-- | Modular inversion over F₂m.
+-- If @n@ doesn't have an inverse, 'Nothing' is returned.
+--
+-- This function is undefined for negative arguments, because their bit
+-- representation is platform-dependent. Zero modulus is also prohibited.
+invF2m :: BinaryPolynomial -- ^ Modulus
+       -> Integer
+       -> Maybe Integer
+invF2m fx n = if g == 1 then Just (modF2m fx u) else Nothing
+  where
+    (g, u, _) = gcdF2m n fx
 {-# INLINABLE invF2m #-}
 
 -- | Division over F₂m. If the dividend doesn't have an inverse it returns
 -- 'Nothing'.
 --
--- Compute n1 / n2
-divF2m :: BinaryPolynomial  -- ^ Irreducible binary polynomial
-       -> Integer  -- ^ Dividend
-       -> Integer  -- ^ Quotient
-       -> Maybe Integer
+-- This function is undefined for negative arguments, because their bit
+-- representation is platform-dependent. Zero modulus is also prohibited.
+divF2m :: BinaryPolynomial -- ^ Modulus
+       -> Integer          -- ^ Dividend
+       -> Integer          -- ^ Divisor
+       -> Maybe Integer    -- ^ Quotient
 divF2m fx n1 n2 = mulF2m fx n1 <$> invF2m fx n2
 {-# INLINE divF2m #-}

--- a/Crypto/Number/F2m.hs
+++ b/Crypto/Number/F2m.hs
@@ -13,6 +13,7 @@ module Crypto.Number.F2m
     ( BinaryPolynomial
     , addF2m
     , mulF2m
+    , squareF2m'
     , squareF2m
     , modF2m
     , invF2m
@@ -64,11 +65,11 @@ mulF2m fx n1 n2 = modF2m fx
 -- Multiplication table? C?
 squareF2m :: BinaryPolynomial  -- ^ Irreducible binary polynomial
           -> Integer -> Integer
-squareF2m fx = modF2m fx . square
+squareF2m fx = modF2m fx . squareF2m'
 {-# INLINE squareF2m #-}
 
-square :: Integer -> Integer
-square n1 = go n1 ln1
+squareF2m' :: Integer -> Integer
+squareF2m' n1 = go n1 ln1
   where
     ln1 = log2 n1
     go n s | s == 0 = n
@@ -76,7 +77,7 @@ square n1 = go n1 ln1
       where
         x = shift (shift n (2 * (s - ln1) - 1)) (2 * (ln1 - s) + 2)
         y = n .&. (shift 1 (2 * (ln1 - s) + 1) - 1)
-{-# INLINE square #-}
+{-# INLINE squareF2m' #-}
 
 -- | Inversion of @n over F₂m using extended Euclidean algorithm.
 --

--- a/Crypto/Number/F2m.hs
+++ b/Crypto/Number/F2m.hs
@@ -23,6 +23,7 @@ module Crypto.Number.F2m
 
 import Data.Bits (xor, shift, testBit, setBit)
 import Data.List
+import Crypto.Internal.Imports
 import Crypto.Number.Basic
 
 -- | Binary Polynomial represented by an integer

--- a/benchs/Number/F2m.hs
+++ b/benchs/Number/F2m.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE PackageImports #-}
+
+module Main where
+
+import Criterion.Main
+import System.Random
+
+import "cryptonite" Crypto.Number.Basic (log2)
+import "cryptonite" Crypto.Number.F2m
+
+genInteger :: Int -> Int -> Integer
+genInteger salt bits
+    = head
+    . dropWhile ((< bits) . log2)
+    . scanl (\a r -> a * 2^31 + abs r) 0
+    . randoms
+    . mkStdGen
+    $ salt + bits
+
+benchMod :: Int -> Benchmark
+benchMod bits = bench (show bits) $ nf (modF2m m) a
+  where
+    m = genInteger 0 bits
+    a = genInteger 1 (2 * bits)
+
+benchMul :: Int -> Benchmark
+benchMul bits = bench (show bits) $ nf (mulF2m m a) b
+  where
+    m = genInteger 0 bits
+    a = genInteger 1 bits
+    b = genInteger 2 bits
+
+benchSquare :: Int -> Benchmark
+benchSquare bits = bench (show bits) $ nf (squareF2m m) a
+  where
+    m = genInteger 0 bits
+    a = genInteger 1 bits
+
+benchInv :: Int -> Benchmark
+benchInv bits = bench (show bits) $ nf (invF2m m) a
+  where
+    m = genInteger 0 bits
+    a = genInteger 1 bits
+
+bitsList :: [Int]
+bitsList = [64, 128, 256, 512, 1024, 2048]
+
+main = defaultMain
+    [ bgroup    "modF2m" $ map benchMod    bitsList
+    , bgroup    "mulF2m" $ map benchMul    bitsList
+    , bgroup "squareF2m" $ map benchSquare bitsList
+    , bgroup    "invF2m" $ map benchInv    bitsList
+    ]

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -308,8 +308,10 @@ Test-Suite test-cryptonite
                      KAT_Camellia
                      KAT_Curve25519
                      KAT_DES
+                     KAT_Ed448
                      KAT_Ed25519
                      KAT_CMAC
+                     KAT_HKDF
                      KAT_HMAC
                      KAT_MiyaguchiPreneel
                      KAT_PBKDF2
@@ -323,6 +325,10 @@ Test-Suite test-cryptonite
                      KAT_RC4
                      KAT_Scrypt
                      KAT_TripleDES
+                     ChaChaPoly1305
+                     Number
+                     Number.F2m
+                     Padding
                      Poly1305
                      Salsa
                      Utils

--- a/tests/Number/F2m.hs
+++ b/tests/Number/F2m.hs
@@ -1,0 +1,83 @@
+module Number.F2m (tests) where
+
+import Imports hiding ((.&.))
+import Data.Bits
+import Crypto.Number.Basic (log2)
+import Crypto.Number.F2m
+
+addTests = testGroup "addF2m"
+    [ testProperty "commutative"
+        $ \a b -> a `addF2m` b == b `addF2m` a
+    , testProperty "associative"
+        $ \a b c -> (a `addF2m` b) `addF2m` c == a `addF2m` (b `addF2m` c)
+    , testProperty "0 is neutral"
+        $ \a -> a `addF2m` 0 == a
+    , testProperty "nullable"
+        $ \a -> a `addF2m` a == 0
+    , testProperty "works per bit"
+        $ \a b -> (a `addF2m` b) .&. b == (a .&. b) `addF2m` b
+    ]
+
+modTests = testGroup "modF2m"
+    [ testProperty "idempotent"
+        $ \(Positive m) (NonNegative a) -> modF2m m a == modF2m m (modF2m m a)
+    , testProperty "upper bound"
+        $ \(Positive m) (NonNegative a) -> modF2m m a < 2 ^ log2 m
+    , testProperty "reach upper"
+        $ \(Positive m) -> let a = 2 ^ log2 m - 1 in modF2m m (m `addF2m` a) == a
+    , testProperty "lower bound"
+        $ \(Positive m) (NonNegative a) -> modF2m m a >= 0
+    , testProperty "reach lower"
+        $ \(Positive m) -> modF2m m m == 0
+    , testProperty "additive"
+        $ \(Positive m) (NonNegative a) (NonNegative b)
+            -> modF2m m a `addF2m` modF2m m b == modF2m m (a `addF2m` b)
+    ]
+
+mulTests = testGroup "mulF2m"
+    [ testProperty "commutative"
+        $ \(Positive m) (NonNegative a) (NonNegative b) -> mulF2m m a b == mulF2m m b a
+    , testProperty "associative"
+        $ \(Positive m) (NonNegative a) (NonNegative b) (NonNegative c)
+            -> mulF2m m (mulF2m m a b) c == mulF2m m a (mulF2m m b c)
+    , testProperty "1 is neutral"
+        $ \(Positive m) (NonNegative a) -> mulF2m m a 1 == modF2m m a
+    , testProperty "0 is annihilator"
+        $ \(Positive m) (NonNegative a) -> mulF2m m a 0 == 0
+    , testProperty "distributive"
+        $ \(Positive m) (NonNegative a) (NonNegative b) (NonNegative c)
+            -> mulF2m m a (b `addF2m` c) == mulF2m m a b `addF2m` mulF2m m a c
+    ]
+
+squareTests = testGroup "squareF2m"
+    [ testProperty "sqr(a) == a * a"
+        $ \(Positive m) (NonNegative a) -> mulF2m m a a == squareF2m m a
+    ]
+
+invTests = testGroup "invF2m"
+    [ testProperty "1 / a * a == 1"
+        $ \(Positive m) (NonNegative a)
+            -> maybe True (\c -> mulF2m m c a == modF2m m 1) (invF2m m a)
+    , testProperty "1 / a == a (mod a^2-1)"
+        $ \(NonNegative a) -> a < 2 || invF2m (squareF2m' a `addF2m` 1) a == Just a
+    ]
+
+divTests = testGroup "divF2m"
+    [ testProperty "1 / a == inv a"
+        $ \(Positive m) (NonNegative a) -> divF2m m 1 a == invF2m m a
+    , testProperty "a / b == a * inv b"
+        $ \(Positive m) (NonNegative a) (NonNegative b)
+            -> divF2m m a b == (mulF2m m a <$> invF2m m b)
+    , testProperty "a * b / b == a"
+        $ \(Positive m) (NonNegative a) (NonNegative b)
+            -> invF2m m b == Nothing || divF2m m (mulF2m m a b) b == Just (modF2m m a)
+    ]
+
+tests = testGroup "number.F2m"
+    [ addTests
+    , modTests
+    , mulTests
+    , squareTests
+    , invTests
+    , divTests
+    ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -4,6 +4,7 @@ module Main where
 import Imports
 
 import qualified Number
+import qualified Number.F2m
 import qualified BCrypt
 import qualified Hash
 import qualified Poly1305
@@ -33,6 +34,7 @@ import qualified Padding
 
 tests = testGroup "cryptonite"
     [ Number.tests
+    , Number.F2m.tests
     , Hash.tests
     , Padding.tests
     , testGroup "ConstructHash"


### PR DESCRIPTION
The aim of the pull request is to refactor `Crypto.Number.F2m` module.

My starting point was a comment near `squareF2m` routine, stating that for unknown reason `squareF2m` is slower than `mulF2m`. So I have written a benchmark for functions over F2m, which clearly showed that `squareF2m` is 2.5-3x slower than `mulF2m`. Another interesting fact was that the benchmark failed with out of memory error on `invF2m` routine with 256bit arguments.

This memory leak led me to writing more or less comprehensive test suite for `Crypto.Number.F2m`. The tests showed thal along with the memory leak in `invF2m` there are many corner cases in other functions. They fall into two categories. The first category includes division by zero modulus - definitely, routines should throw an error in this case.

The second category of test failures was caused by negative numbers. The module represents polynomials over F2m (isomorphic to bit vectors) by `Integer` values. For example, `1` represents the polynomial of zero degree `1`. However, it is not clear which polynomial is represented by `-1`: is it `x^63 + x^62 + ... + 1` or `x^31 + x^30 + ... + 1`? That means that the result of computations is platform dependent: basically, encryption over elliptic curve on 64bit architecture cannot be decrypted on 32bit architecture.

More over, with negative `Integers` there are two very different representations for every polynomial. On 64bit machine `x^63 + x^62 + ... + 1` is represented both by `-1` (`S# I#`) and by `18446744073709551615` (`Jp# BigNat`). It does not make much sense to allow both of them.

That said, I decided to restrict input of routines over F2m to non-negative `Integer`. One can check that given non-negative inputs they produce non-negative outputs.

Further, I have fixed the memory leak in `invF2m`. It was caused by infinite recursion. The underlying extended GCD algorithm was rewritten in a more clear and robust way (now it handles correctly all polynomials, not only irreducible ones).

That said, I was able to return to speeding up `squareF2m`. I have rewritten it as a very simple one-liner, improving its running time 3x. Now it is 10% faster than `mulF2m`. This comparison is not very impressive - one may expect `squareF2m` to run in linear time, while `mulF2m` runs in quadratic time. The reason is that `setBit` on `Integer` has linear complexity (not `O(1)` as one may expect).

In future it may be worth of effort to replace `Integer` with true bit vectors (e. g., from `bitvec` package): they would both solve mess with signs and speed up `squareF2m` asymptotically, because `setBit` is a constant-time operation for bit vector.

BTW I have tried to use Karatsuba multiplication for `mulF2m`, but it appeared to be fruitful only for very large polynomials (5000 bits and more), so I reverted the change.

As a detour, I have fixed a bug in `Crypto.PubKey.ECC.Prim.pointMul`, when a point on `CurveF2m` was multiplied by negative factor. The negation on `CurveFP` and `CurveF2m` works differently, see new `negatePoint` routine. It also simplified a bit the code of `pointAdd`.
