### PR TITLE
Derive Show instance for CryptoFailable

### DIFF
--- a/Crypto/Error/Types.hs
+++ b/Crypto/Error/Types.hs
@@ -52,10 +52,8 @@ instance E.Exception CryptoError
 data CryptoFailable a =
       CryptoPassed a
     | CryptoFailed CryptoError
+    deriving (Show)
 
-instance Show a => Show (CryptoFailable a) where
-    show (CryptoPassed a)   = "CryptoPassed " ++ show a
-    show (CryptoFailed err) = "CryptoFailed " ++ show err
 instance Eq a => Eq (CryptoFailable a) where
     (==) (CryptoPassed a)  (CryptoPassed b)  = a == b
     (==) (CryptoFailed e1) (CryptoFailed e2) = e1 == e2


### PR DESCRIPTION
Fixes #50

The derived instances use precedences to decide when
parentheses are appropriate.
