### PR TITLE
Add Byteable instance.

### DIFF
--- a/Crypto/Hash/Types.hs
+++ b/Crypto/Hash/Types.hs
@@ -17,6 +17,7 @@ module Crypto.Hash.Types
 import           Crypto.Internal.Imports
 import           Crypto.Internal.ByteArray (ByteArrayAccess, Bytes)
 import qualified Crypto.Internal.ByteArray as B
+import           Data.Byteable (Byteable, toBytes)
 import           Foreign.Ptr (Ptr)
 
 -- | Class representing hashing algorithms.
@@ -56,3 +57,6 @@ newtype Digest a = Digest Bytes
 instance Show (Digest a) where
     show (Digest bs) = map (toEnum . fromIntegral)
                      $ B.unpack (B.convertToBase B.Base16 bs :: Bytes)
+
+instance Byteable (Digest a) where
+    toBytes (Digest bs) = B.pack $ B.unpack (bs :: Bytes)

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -191,6 +191,7 @@ Library
                      Crypto.Internal.Words
                      Crypto.Internal.WordArray
   Build-depends:     base >= 4.3 && < 5
+                   , byteable
                    , bytestring
                    , memory >= 0.8
                    , ghc-prim


### PR DESCRIPTION
This seems like an innocuous change, is there a reason it hasn't already been implemented?
