### PR TITLE
Fix ECDH/ECDSA when scalar and coordinate bit sizes differ

### DIFF
--- a/Crypto/PubKey/ECC/Types.hs
+++ b/Crypto/PubKey/ECC/Types.hs
@@ -164,7 +164,8 @@ curvesOIDs =
 
 -- | get the size of the curve in bits
 curveSizeBits :: Curve -> Int
-curveSizeBits = numBits . ecc_n . common_curve
+curveSizeBits (CurveFP  c) = numBits (ecc_p  c)
+curveSizeBits (CurveF2m c) = numBits (ecc_fx c) - 1
 
 -- | Get the curve definition associated with a recommended known curve name.
 getCurveByName :: CurveName -> Curve


### PR DESCRIPTION
I found more bit-alignment issues when testing handshake between `tls` and
OpenSSL using less frequent elliptic curves.  In the implementation of ECDH
and ECDSA there is sometimes a confusion between the curve order `n` and the
size of the finite-field.

The public-key components exchanged during handshake are point coordinates
and should use the bit size of the finite field, instead of the order `ecc_n`
which is for scalars.  For P-256 both sizes match, but for other curves they
may differ.

This pull request changes the function `curveSizeBits` exported from
`Crypto.PubKey.ECC.Types` to return the bit length of the finite field instead
of the order `n`.

i.e. change:

``` haskell
curveSizeBits = numBits . ecc_n . common_curve
```

to the following:

``` haskell
curveSizeBits (CurveFP  c) = numBits (ecc_p  c)
curveSizeBits (CurveF2m c) = numBits (ecc_fx c) - 1
```

I believe having this two-equation definition here is more useful.  And the
change would then make it easier to fix byte lengths computed in `tls` and
`x509-validation` (just use a function from the existing API instead of
duplicating code).

`curveSizeBits` is used in cryptonite module `Crypto.PubKey.ECC.DH`, which
sometimes fails with the current definition based on `ecc_n`.  None of
48 reverse dependencies on hackage reference `curveSizeBits` currently.

I prepared changes to other packages here for preview:
- [x509-validation](https://github.com/vincenthz/hs-certificate/compare/master...ocheron:ecc-bitsize-fixes)
- [tls](https://github.com/vincenthz/hs-tls/compare/master...ocheron:ecc-bitsize-fixes)
