### PR TITLE
Implement Shamir's trick

### DIFF
--- a/Crypto/PubKey/ECC/ECDSA.hs
+++ b/Crypto/PubKey/ECC/ECDSA.hs
@@ -102,10 +102,7 @@ verify hashAlg pk@(PublicKey curve q) (Signature r s) msg
         let z  = tHash hashAlg msg n
             u1 = z * w `mod` n
             u2 = r * w `mod` n
-            -- TODO: Use Shamir's trick
-            g' = pointMul curve u1 g
-            q' = pointMul curve u2 q
-            x  = pointAdd curve g' q'
+            x  = pointAddTwoMuls curve u1 g u2 q
         case x of
              PointO     -> Nothing
              Point x1 _ -> return $ x1 `mod` n

--- a/benchs/Bench.hs
+++ b/benchs/Bench.hs
@@ -7,19 +7,17 @@ import Criterion.Main
 import "cryptonite" Crypto.Hash
 import "cryptonite" Crypto.Error
 import "cryptonite" Crypto.Cipher.DES
-import "cryptonite" Crypto.Cipher.Camellia
 import "cryptonite" Crypto.Cipher.AES
 import "cryptonite" Crypto.Cipher.Blowfish
 import "cryptonite" Crypto.Cipher.Types
 import qualified "cryptonite" Crypto.Cipher.ChaChaPoly1305 as CP
 
-import "cryptonite" Crypto.Hash (SHA512(..))
 import qualified "cryptonite" Crypto.KDF.PBKDF2 as PBKDF2
 
 import qualified "cryptonite" Crypto.PubKey.ECC.Types as ECC
 import qualified "cryptonite" Crypto.PubKey.ECC.Prim as ECC
 
-import Data.ByteArray (ByteArray, Bytes)
+import Data.ByteArray (ByteArray)
 
 import qualified Data.ByteString as B
 

--- a/benchs/Bench.hs
+++ b/benchs/Bench.hs
@@ -16,6 +16,9 @@ import qualified "cryptonite" Crypto.Cipher.ChaChaPoly1305 as CP
 import "cryptonite" Crypto.Hash (SHA512(..))
 import qualified "cryptonite" Crypto.KDF.PBKDF2 as PBKDF2
 
+import qualified "cryptonite" Crypto.PubKey.ECC.Types as ECC
+import qualified "cryptonite" Crypto.PubKey.ECC.Prim as ECC
+
 import Data.ByteArray (ByteArray, Bytes)
 
 import qualified Data.ByteString as B
@@ -103,9 +106,27 @@ benchAE =
 
         key32 = B.replicate 32 0
 
+benchECC =
+    [ bench "pointAddTwoMuls-baseline"  $ nf run_b (n1, p1, n2, p2)
+    , bench "pointAddTwoMuls-optimized" $ nf run_o (n1, p1, n2, p2)
+    ]
+  where run_b (n, p, k, q) = ECC.pointAdd c (ECC.pointMul c n p)
+                                            (ECC.pointMul c k q)
+
+        run_o (n, p, k, q) = ECC.pointAddTwoMuls c n p k q
+
+        c  = ECC.getCurveByName ECC.SEC_p256r1
+        r1 = 7
+        r2 = 11
+        p1 = ECC.pointBaseMul c r1
+        p2 = ECC.pointBaseMul c r2
+        n1 = 0x2ba9daf2363b2819e69b34a39cf496c2458a9b2a21505ea9e7b7cbca42dc7435
+        n2 = 0xf054a7f60d10b8c2cf847ee90e9e029f8b0e971b09ca5f55c4d49921a11fadc1
+
 main = defaultMain
     [ bgroup "hash" benchHash
     , bgroup "block-cipher" benchBlockCipher
     , bgroup "AE" benchAE
     , bgroup "pbkdf2" benchPBKDF2
+    , bgroup "ECC" benchECC
     ]

--- a/tests/KAT_PubKey/ECC.hs
+++ b/tests/KAT_PubKey/ECC.hs
@@ -155,12 +155,14 @@ eccTests = testGroup "ECC"
                 p2       = ECC.pointMul aCurve r2 curveGen
                 pR       = ECC.pointMul aCurve ((r1 + r2) `mod` curveN) curveGen
              in pR `propertyEq` ECC.pointAdd aCurve p1 p2
-        , testProperty "point-mul-mul" $ \aCurve (QAInteger n1) (QAInteger n2) -> do
+        , localOption (QuickCheckTests 20) $
+          testProperty "point-mul-mul" $ \aCurve (QAInteger n1) (QAInteger n2) -> do
             p <- arbitraryPoint aCurve
             let pRes = ECC.pointMul aCurve (n1 * n2) p
             let pDef = ECC.pointMul aCurve n1 (ECC.pointMul aCurve n2 p)
             return $ pRes `propertyEq` pDef
-        , testProperty "double-scalar-mult" $ \aCurve (QAInteger n1) (QAInteger n2) -> do
+        , localOption (QuickCheckTests 20) $
+          testProperty "double-scalar-mult" $ \aCurve (QAInteger n1) (QAInteger n2) -> do
             p1 <- arbitraryPoint aCurve
             p2 <- arbitraryPoint aCurve
             let pRes = ECC.pointAddTwoMuls aCurve n1 p1 n2 p2


### PR DESCRIPTION
I implemented this to understand what it was about.

The speed increase is in the order of what is expected (calls to `pointDouble` halved):

```
benchmarking ECC/pointAddTwoMuls-baseline
time                 3.006 ms   (2.996 ms .. 3.015 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.020 ms   (3.017 ms .. 3.024 ms)
std dev              12.09 μs   (9.415 μs .. 17.38 μs)

benchmarking ECC/pointAddTwoMuls-optimized
time                 1.770 ms   (1.763 ms .. 1.776 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.770 ms   (1.768 ms .. 1.773 ms)
std dev              9.464 μs   (7.276 μs .. 13.67 μs)
```
