### PR TITLE
Extending ECC and ECIES

### DIFF
--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -1,0 +1,112 @@
+-- |
+-- Module      : Crypto.ECC
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : unknown
+--
+-- Elliptic Curve Cryptography
+--
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+module Crypto.ECC
+    ( Curve_P256R1(..)
+    , Curve_P521R1(..)
+    , EllipticCurve(..)
+    , EllipticCurveDH(..)
+    , EllipticCurveArith(..)
+    , KeyPair(..)
+    , SharedSecret(..)
+    ) where
+
+import qualified Crypto.PubKey.ECC.P256 as P256
+import qualified Crypto.PubKey.ECC.Types as H
+import qualified Crypto.PubKey.ECC.Prim as H
+import           Crypto.Random
+import           Crypto.Internal.ByteArray (ByteArrayAccess, ScrubbedBytes)
+import           Data.Function (on)
+
+-- | An elliptic curve key pair composed of the private part (a scalar), and
+-- the associated point.
+data KeyPair curve = KeyPair
+    { keypairGetPublic  :: !(Point curve)
+    , keypairGetPrivate :: !(Scalar curve)
+    }
+
+newtype SharedSecret = SharedSecret ScrubbedBytes
+    deriving (Eq, ByteArrayAccess)
+
+class EllipticCurve curve where
+    -- | Point on an Elliptic Curve
+    data Point curve  :: *
+
+    -- | Scalar in the Elliptic Curve domain
+    data Scalar curve :: *
+
+    -- | get the order of the Curve
+    curveGetOrder :: curve -> Integer
+
+    -- | get the curve related to a point on a curve
+    curveOfPoint :: Point curve -> curve
+
+    -- | get the curve related to a curve's scalar
+    curveOfScalar :: Scalar curve -> curve
+
+    -- | get the base point of the Curve
+    curveGetBasePoint :: Point curve
+
+    -- | Generate a new random scalar on the curve.
+    -- The scalar will represent a number between 1 and the order of the curve non included
+    curveGenerateScalar :: MonadRandom randomly => randomly (Scalar curve)
+
+    -- | Generate a new random keypair
+    curveGenerateKeyPair :: MonadRandom randomly => randomly (KeyPair curve)
+
+class EllipticCurve curve => EllipticCurveDH curve where
+    -- | Generate a Diffie hellman secret
+    ecdh :: Scalar curve -> Point curve -> SharedSecret
+
+class EllipticCurve curve => EllipticCurveArith curve where
+    -- | Add points on a curve
+    pointAdd :: Point curve -> Point curve -> Point curve
+
+    -- | Scalar Multiplication on a curve
+    pointSmul :: Scalar curve -> Point curve -> Point curve
+
+-- | P256 Curve
+--
+-- also known as P256
+data Curve_P256R1 = Curve_P256R1
+
+instance EllipticCurve Curve_P256R1 where
+    newtype Point Curve_P256R1 = P256Point { unP256Point :: P256.Point }
+    newtype Scalar Curve_P256R1 = P256Scalar { unP256Scalar :: P256.Scalar }
+    curveGetOrder     _ = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
+    curveGetBasePoint = P256Point P256.pointBase
+    curveOfScalar _ = Curve_P256R1
+    curveOfPoint _ = Curve_P256R1
+    curveGenerateScalar = P256Scalar <$> P256.scalarGenerate
+    curveGenerateKeyPair = toKeyPair <$> P256.scalarGenerate
+      where toKeyPair scalar = KeyPair (P256Point $ P256.toPoint scalar) (P256Scalar scalar)
+instance EllipticCurveArith Curve_P256R1 where
+    pointAdd  a b = P256Point $ (P256.pointAdd `on` unP256Point) a b
+    pointSmul s p = P256Point $ P256.pointMul (unP256Scalar s) (unP256Point p)
+instance EllipticCurveDH Curve_P256R1 where
+    ecdh s p = undefined
+
+data Curve_P521R1 = Curve_P521R1
+
+instance EllipticCurve Curve_P521R1 where
+    newtype Point Curve_P521R1 = P521Point { unP521Point :: H.Point }
+    newtype Scalar Curve_P521R1 = P521Scalar { unP521Scalar :: H.PrivateNumber }
+    curveGetOrder _ = H.ecc_n $ H.common_curve $ H.getCurveByName H.SEC_p521r1
+    curveGetBasePoint = P521Point $ H.ecc_g $ H.common_curve $ H.getCurveByName H.SEC_p521r1
+    curveOfScalar _ = Curve_P521R1
+    curveOfPoint _ = Curve_P521R1
+    curveGenerateScalar = P521Scalar <$> H.scalarGenerate (H.getCurveByName H.SEC_p521r1)
+    curveGenerateKeyPair = toKeyPair <$> H.scalarGenerate (H.getCurveByName H.SEC_p521r1)
+      where toKeyPair scalar = KeyPair (P521Point $ H.pointBaseMul (H.getCurveByName H.SEC_p521r1) scalar) (P521Scalar scalar)
+instance EllipticCurveArith Curve_P521R1 where
+    pointAdd a b = P521Point $ (H.pointAdd (H.getCurveByName H.SEC_p521r1) `on` unP521Point) a b
+    pointSmul s p = P521Point (H.pointMul (H.getCurveByName H.SEC_p521r1) (unP521Scalar s) (unP521Point p))
+

--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -63,7 +63,12 @@ class EllipticCurve curve where
     curveGenerateKeyPair :: MonadRandom randomly => randomly (KeyPair curve)
 
 class EllipticCurve curve => EllipticCurveDH curve where
-    -- | Generate a Diffie hellman secret
+    -- | Generate a Diffie hellman secret value.
+    --
+    -- This is generally just the .x coordinate of the resulting point, that
+    -- is not hashed.
+    --
+    -- use `pointSmul` to keep the result in Point format.
     ecdh :: Scalar curve -> Point curve -> SharedSecret
 
 class EllipticCurve curve => EllipticCurveArith curve where

--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -25,6 +25,7 @@ import qualified Crypto.PubKey.ECC.Prim as H
 import           Crypto.Random
 import           Crypto.Internal.Imports
 import           Crypto.Internal.ByteArray (ByteArrayAccess, ScrubbedBytes)
+import           Crypto.Number.Serialize (i2ospOf_)
 import           Data.Function (on)
 
 -- | An elliptic curve key pair composed of the private part (a scalar), and
@@ -97,11 +98,17 @@ instance EllipticCurve Curve_P256R1 where
     curveGenerateScalar = P256Scalar <$> P256.scalarGenerate
     curveGenerateKeyPair = toKeyPair <$> P256.scalarGenerate
       where toKeyPair scalar = KeyPair (P256Point $ P256.toPoint scalar) (P256Scalar scalar)
+
 instance EllipticCurveArith Curve_P256R1 where
     pointAdd  a b = P256Point $ (P256.pointAdd `on` unP256Point) a b
     pointSmul s p = P256Point $ P256.pointMul (unP256Scalar s) (unP256Point p)
+
 instance EllipticCurveDH Curve_P256R1 where
-    ecdh s p = undefined
+    ecdh s p = shared
+      where
+        (x, _) = P256.pointToIntegers $ unP256Point $ pointSmul s p
+        len = (256 + 7) `div` 8
+        shared = SharedSecret $ i2ospOf_ len x
 
 data Curve_P521R1 = Curve_P521R1
 
@@ -115,7 +122,14 @@ instance EllipticCurve Curve_P521R1 where
     curveGenerateScalar = P521Scalar <$> H.scalarGenerate (H.getCurveByName H.SEC_p521r1)
     curveGenerateKeyPair = toKeyPair <$> H.scalarGenerate (H.getCurveByName H.SEC_p521r1)
       where toKeyPair scalar = KeyPair (P521Point $ H.pointBaseMul (H.getCurveByName H.SEC_p521r1) scalar) (P521Scalar scalar)
+
 instance EllipticCurveArith Curve_P521R1 where
     pointAdd a b = P521Point $ (H.pointAdd (H.getCurveByName H.SEC_p521r1) `on` unP521Point) a b
     pointSmul s p = P521Point (H.pointMul (H.getCurveByName H.SEC_p521r1) (unP521Scalar s) (unP521Point p))
 
+instance EllipticCurveDH Curve_P521R1 where
+    ecdh s p = shared
+      where
+        H.Point x _ = unP521Point $ pointSmul s p
+        len = (521 + 7) `div` 8
+        shared = SharedSecret $ i2ospOf_ len x

--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -68,6 +68,18 @@ class EllipticCurve curve where
     -- | Generate a new random keypair
     curveGenerateKeyPair :: MonadRandom randomly => randomly (KeyPair curve)
 
+instance {-# OVERLAPPABLE #-} Show (Point a) where
+    show _ = undefined
+
+instance {-# OVERLAPPABLE #-} Eq (Point a) where
+    _ == _ = undefined
+
+instance {-# OVERLAPPABLE #-} Show (Scalar a) where
+    show _ = undefined
+
+instance {-# OVERLAPPABLE #-} Eq (Scalar a) where
+    _ == _ = undefined
+
 class EllipticCurve curve => EllipticCurveDH curve where
     -- | Generate a Diffie hellman secret value.
     --
@@ -93,8 +105,8 @@ class EllipticCurve curve => EllipticCurveArith curve where
 data Curve_P256R1 = Curve_P256R1
 
 instance EllipticCurve Curve_P256R1 where
-    newtype Point Curve_P256R1 = P256Point { unP256Point :: P256.Point }
-    newtype Scalar Curve_P256R1 = P256Scalar { unP256Scalar :: P256.Scalar }
+    newtype Point Curve_P256R1 = P256Point { unP256Point :: P256.Point } deriving (Eq,Show)
+    newtype Scalar Curve_P256R1 = P256Scalar { unP256Scalar :: P256.Scalar } deriving (Eq,Show)
     curveGetOrder     _ = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
     curveGetBasePoint = P256Point P256.pointBase
     curveOfScalar _ = Curve_P256R1
@@ -117,8 +129,8 @@ instance EllipticCurveDH Curve_P256R1 where
 data Curve_P384R1 = Curve_P384R1
 
 instance EllipticCurve Curve_P384R1 where
-    newtype Point Curve_P384R1 = P384Point { unP384Point :: H.Point }
-    newtype Scalar Curve_P384R1 = P384Scalar { unP384Scalar :: H.PrivateNumber }
+    newtype Point Curve_P384R1 = P384Point { unP384Point :: H.Point } deriving (Eq,Show)
+    newtype Scalar Curve_P384R1 = P384Scalar { unP384Scalar :: H.PrivateNumber } deriving (Eq,Show)
     curveGetOrder _ = H.ecc_n $ H.common_curve $ H.getCurveByName H.SEC_p384r1
     curveGetBasePoint = P384Point $ H.ecc_g $ H.common_curve $ H.getCurveByName H.SEC_p384r1
     curveOfScalar _ = Curve_P384R1
@@ -141,8 +153,8 @@ instance EllipticCurveDH Curve_P384R1 where
 data Curve_P521R1 = Curve_P521R1
 
 instance EllipticCurve Curve_P521R1 where
-    newtype Point Curve_P521R1 = P521Point { unP521Point :: H.Point }
-    newtype Scalar Curve_P521R1 = P521Scalar { unP521Scalar :: H.PrivateNumber }
+    newtype Point Curve_P521R1 = P521Point { unP521Point :: H.Point } deriving (Eq,Show)
+    newtype Scalar Curve_P521R1 = P521Scalar { unP521Scalar :: H.PrivateNumber } deriving (Eq,Show)
     curveGetOrder _ = H.ecc_n $ H.common_curve $ H.getCurveByName H.SEC_p521r1
     curveGetBasePoint = P521Point $ H.ecc_g $ H.common_curve $ H.getCurveByName H.SEC_p521r1
     curveOfScalar _ = Curve_P521R1
@@ -165,8 +177,8 @@ instance EllipticCurveDH Curve_P521R1 where
 data Curve_X25519 = Curve_X25519
 
 instance EllipticCurve Curve_X25519 where
-    newtype Point Curve_X25519 = X25519Point X25519.PublicKey
-    newtype Scalar Curve_X25519 = X25519Scalar X25519.SecretKey
+    newtype Point Curve_X25519 = X25519Point X25519.PublicKey deriving (Eq,Show)
+    newtype Scalar Curve_X25519 = X25519Scalar X25519.SecretKey deriving (Eq,Show)
     curveGetOrder     _ = undefined
     curveGetBasePoint = undefined
     curveOfScalar _ = Curve_X25519

--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -23,6 +23,7 @@ import qualified Crypto.PubKey.ECC.P256 as P256
 import qualified Crypto.PubKey.ECC.Types as H
 import qualified Crypto.PubKey.ECC.Prim as H
 import           Crypto.Random
+import           Crypto.Internal.Imports
 import           Crypto.Internal.ByteArray (ByteArrayAccess, ScrubbedBytes)
 import           Data.Function (on)
 

--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -79,6 +79,9 @@ class EllipticCurve curve => EllipticCurveArith curve where
     -- | Scalar Multiplication on a curve
     pointSmul :: Scalar curve -> Point curve -> Point curve
 
+--   -- | Scalar Inverse
+--   scalarInverse :: Scalar curve -> Scalar curve
+
 -- | P256 Curve
 --
 -- also known as P256

--- a/Crypto/KDF/HKDF.hs
+++ b/Crypto/KDF/HKDF.hs
@@ -30,10 +30,6 @@ import qualified Data.ByteString as BS
 data PRK a = PRK (HMAC a) | PRK_NoExpand ScrubbedBytes
     deriving (Eq)
 
-instance Show (PRK a) where
-    show (PRK hm) = show (hmacGetDigest hm)
-    show (PRK_NoExpand sb) = show sb
-
 toByteString :: PRK a -> BS.ByteString
 toByteString (PRK hm)          = B.convert hm
 toByteString (PRK_NoExpand sb) = B.convert sb

--- a/Crypto/KDF/HKDF.hs
+++ b/Crypto/KDF/HKDF.hs
@@ -15,8 +15,8 @@ module Crypto.KDF.HKDF
     , extract
     , extractSkip
     , expand
-    , toByteString
-    , fromByteString
+    , fromPRK
+    , toPRK
     ) where
 
 import           Data.Word
@@ -24,18 +24,17 @@ import           Crypto.Hash
 import           Crypto.MAC.HMAC
 import           Crypto.Internal.ByteArray (ScrubbedBytes, ByteArray, ByteArrayAccess)
 import qualified Crypto.Internal.ByteArray as B
-import qualified Data.ByteString as BS
 
 -- | Pseudo Random Key
 data PRK a = PRK (HMAC a) | PRK_NoExpand ScrubbedBytes
     deriving (Eq)
 
-toByteString :: PRK a -> BS.ByteString
-toByteString (PRK hm)          = B.convert hm
-toByteString (PRK_NoExpand sb) = B.convert sb
+fromPRK :: ByteArray b => PRK a -> b
+fromPRK (PRK hm)          = B.convert hm
+fromPRK (PRK_NoExpand sb) = B.convert sb
 
-fromByteString :: BS.ByteString -> PRK a
-fromByteString = extractSkip
+toPRK :: ByteArrayAccess b => b -> PRK a
+toPRK = extractSkip
 
 -- | Extract a Pseudo Random Key using the parameter and the underlaying hash mechanism
 extract :: (HashAlgorithm a, ByteArrayAccess salt, ByteArrayAccess ikm)

--- a/Crypto/KDF/HKDF.hs
+++ b/Crypto/KDF/HKDF.hs
@@ -20,9 +20,9 @@ module Crypto.KDF.HKDF
     ) where
 
 import           Data.Word
-import           Crypto.Hash 
+import           Crypto.Hash
 import           Crypto.MAC.HMAC
-import           Crypto.Internal.ByteArray (ScrubbedBytes, Bytes, ByteArray, ByteArrayAccess)
+import           Crypto.Internal.ByteArray (ScrubbedBytes, ByteArray, ByteArrayAccess)
 import qualified Crypto.Internal.ByteArray as B
 import qualified Data.ByteString as BS
 

--- a/Crypto/KDF/HKDF.hs
+++ b/Crypto/KDF/HKDF.hs
@@ -15,8 +15,6 @@ module Crypto.KDF.HKDF
     , extract
     , extractSkip
     , expand
-    , fromPRK
-    , toPRK
     ) where
 
 import           Data.Word
@@ -29,12 +27,11 @@ import qualified Crypto.Internal.ByteArray as B
 data PRK a = PRK (HMAC a) | PRK_NoExpand ScrubbedBytes
     deriving (Eq)
 
-fromPRK :: ByteArray b => PRK a -> b
-fromPRK (PRK hm)          = B.convert hm
-fromPRK (PRK_NoExpand sb) = B.convert sb
-
-toPRK :: ByteArrayAccess b => b -> PRK a
-toPRK = extractSkip
+instance ByteArrayAccess (PRK a) where
+    length (PRK hm)          = B.length hm
+    length (PRK_NoExpand sb) = B.length sb
+    withByteArray (PRK hm)          = B.withByteArray hm
+    withByteArray (PRK_NoExpand sb) = B.withByteArray sb
 
 -- | Extract a Pseudo Random Key using the parameter and the underlaying hash mechanism
 extract :: (HashAlgorithm a, ByteArrayAccess salt, ByteArrayAccess ikm)

--- a/Crypto/PubKey/Curve25519.hs
+++ b/Crypto/PubKey/Curve25519.hs
@@ -18,6 +18,8 @@ module Crypto.PubKey.Curve25519
     , dhSecret
     , publicKey
     , secretKey
+    , toPublicKey
+    , fromPublicKey
     -- * methods
     , dh
     , toPublic
@@ -128,3 +130,11 @@ generateSecretKey = return $ unsafeDoIO $ do
         pokeByteOff inp 31 ((e31 .&. 0x7f) .|. 0x40)
     let CryptoPassed s = secretKey bs
     return s
+
+toPublicKey :: ByteString -> PublicKey
+toPublicKey bs = pub
+  where
+    CryptoPassed pub = publicKey bs
+
+fromPublicKey :: PublicKey -> ByteString
+fromPublicKey (PublicKey b) = B.convert b

--- a/Crypto/PubKey/Curve25519.hs
+++ b/Crypto/PubKey/Curve25519.hs
@@ -27,7 +27,6 @@ module Crypto.PubKey.Curve25519
     ) where
 
 import           Data.Bits
-import           Data.ByteString (ByteString)
 import           Data.Word
 import           Foreign.Ptr
 import           Foreign.Storable
@@ -36,7 +35,7 @@ import           GHC.Ptr
 import           Crypto.Error
 import           Crypto.Internal.Compat
 import           Crypto.Internal.Imports
-import           Crypto.Internal.ByteArray (ByteArrayAccess, ScrubbedBytes, Bytes, withByteArray)
+import           Crypto.Internal.ByteArray (ByteArrayAccess, ByteArray, ScrubbedBytes, Bytes, withByteArray)
 import qualified Crypto.Internal.ByteArray as B
 import           Crypto.Error (CryptoFailable(..))
 import           Crypto.Random
@@ -120,6 +119,7 @@ foreign import ccall "cryptonite_curve25519_donna"
                            -> Ptr Word8 -- ^ basepoint
                            -> IO ()
 
+-- | Generate a secret key.
 generateSecretKey :: MonadRandom m => m SecretKey
 generateSecretKey = return $ unsafeDoIO $ do
     sb <- getRandomBytes 32
@@ -130,10 +130,12 @@ generateSecretKey = return $ unsafeDoIO $ do
         pokeByteOff inp 31 ((e31 .&. 0x7f) .|. 0x40)
     return $ SecretKey sb
 
-toPublicKey :: ByteString -> PublicKey
+-- | Create a public key.
+toPublicKey :: ByteArrayAccess bs => bs -> PublicKey
 toPublicKey bs = pub
   where
     CryptoPassed pub = publicKey bs
 
-fromPublicKey :: PublicKey -> ByteString
+-- | Convert a public key.
+fromPublicKey :: ByteArray bs => PublicKey -> bs
 fromPublicKey (PublicKey b) = B.convert b

--- a/Crypto/PubKey/Curve25519.hs
+++ b/Crypto/PubKey/Curve25519.hs
@@ -122,14 +122,13 @@ foreign import ccall "cryptonite_curve25519_donna"
 
 generateSecretKey :: MonadRandom m => m SecretKey
 generateSecretKey = return $ unsafeDoIO $ do
-    bs :: ByteString <- getRandomBytes 32
-    withByteArray bs $ \inp -> do
+    sb <- getRandomBytes 32
+    withByteArray sb $ \inp -> do
         e0 :: Word8 <- peek inp
         poke inp (e0 .&. 0xf8)
         e31 :: Word8 <- peekByteOff inp 31
         pokeByteOff inp 31 ((e31 .&. 0x7f) .|. 0x40)
-    let CryptoPassed s = secretKey bs
-    return s
+    return $ SecretKey sb
 
 toPublicKey :: ByteString -> PublicKey
 toPublicKey bs = pub

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -56,7 +56,7 @@ import qualified Crypto.Number.Serialize as S (os2ip, i2ospOf)
 
 -- | A P256 scalar
 newtype Scalar = Scalar ScrubbedBytes
-    deriving (Eq,ByteArrayAccess)
+    deriving (Show,Eq,ByteArrayAccess)
 
 -- | A P256 point
 newtype Point = Point Bytes

--- a/Crypto/PubKey/ECIES.hs
+++ b/Crypto/PubKey/ECIES.hs
@@ -1,0 +1,33 @@
+-- |
+-- Module      : Crypto.PubKey.ECIES
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : unknown
+--
+-- IES with Elliptic curve <https://en.wikipedia.org/wiki/Integrated_Encryption_Scheme>
+--
+module Crypto.PubKey.ECIES
+    ( deriveEncrypt
+    , deriveDecrypt
+    ) where
+
+import           Crypto.ECC
+import           Crypto.Random
+
+-- | Generate random a new Shared secret and the associated point
+-- to do a ECIES style encryption
+deriveEncrypt :: (MonadRandom randomly, EllipticCurveDH curve)
+              => Point curve -- ^ the public key of the receiver
+              -> randomly (Point curve, SharedSecret)
+deriveEncrypt pub = do
+    (KeyPair rPoint rScalar) <- curveGenerateKeyPair
+    return (rPoint, ecdh rScalar pub)
+
+-- | Derive the shared secret with the receiver key
+-- and the R point of the scheme.
+deriveDecrypt :: EllipticCurveDH curve
+              => Point curve  -- ^ The received R (supposedly, randomly generate on the encrypt side)
+              -> Scalar curve -- ^ The secret key of the receiver
+              -> SharedSecret
+deriveDecrypt point secret = ecdh secret point

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -101,6 +101,7 @@ Library
                      Crypto.ConstructHash.MiyaguchiPreneel
                      Crypto.Data.AFIS
                      Crypto.Data.Padding
+                     Crypto.ECC
                      Crypto.Error
                      Crypto.MAC.CMAC
                      Crypto.MAC.Poly1305
@@ -129,6 +130,7 @@ Library
                      Crypto.PubKey.ECC.ECDSA
                      Crypto.PubKey.ECC.P256
                      Crypto.PubKey.ECC.Types
+                     Crypto.PubKey.ECIES
                      Crypto.PubKey.Ed25519
                      Crypto.PubKey.Ed448
                      Crypto.PubKey.RSA


### PR DESCRIPTION
This patches extend the rebased `ecc` branch to support ECDH, P384 and X25521.
I confirmed that this can be use in the `tls` library.

This also extends PRK which is necessary to implement TLS1.3.

Please give me comments.