### PR TITLE
Timing safe equality operator for Digest

### DIFF
--- a/Crypto/Hash/Types.hs
+++ b/Crypto/Hash/Types.hs
@@ -51,7 +51,10 @@ newtype Context a = Context Bytes
 
 -- | Represent a digest for a given hash algorithm.
 newtype Digest a = Digest Bytes
-    deriving (Eq,Ord,ByteArrayAccess,NFData)
+    deriving (Ord,ByteArrayAccess,NFData)
+
+instance Eq (Digest a) where
+    (Digest a) == (Digest b) = a `B.constEq` b
 
 instance Show (Digest a) where
     show (Digest bs) = map (toEnum . fromIntegral)


### PR DESCRIPTION
Becuase `(==)` operator of `Bytes` is not constant time and `Eq` for `Digest` had been just derived, comparing two `Digest` values could theoretically reveal information for timing analysis through content-based short circuit behavior.

[`Data.ByteArray.constEq`][1] function is a constant time equality test, so it's appropriate for cryptography.  This patch makes `Digest` to prevent timing analysis by implementing `Eq` instance — `(==)` operator — using [`constEq`][1] function instead of deriving `Eq` typeclass.

[1]: http://hackage.haskell.org/package/memory-0.14/docs/Data-ByteArray.html#v:constEq