### PR TITLE
Hash benchmarks

### DIFF
--- a/benchs/Bench.hs
+++ b/benchs/Bench.hs
@@ -4,22 +4,21 @@ module Main where
 
 import Criterion.Main
 
-import "cryptonite" Crypto.Hash
-import "cryptonite" Crypto.Error
-import "cryptonite" Crypto.Cipher.DES
-import "cryptonite" Crypto.Cipher.AES
-import "cryptonite" Crypto.Cipher.Blowfish
-import "cryptonite" Crypto.Cipher.Types
-import qualified "cryptonite" Crypto.Cipher.ChaChaPoly1305 as CP
+import           Crypto.Cipher.AES
+import           Crypto.Cipher.Blowfish
+import qualified Crypto.Cipher.ChaChaPoly1305 as CP
+import           Crypto.Cipher.DES
+import           Crypto.Cipher.Types
+import           Crypto.Error
+import           Crypto.Hash
+import qualified Crypto.KDF.PBKDF2 as PBKDF2
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.ECC.Prim as ECC
 
-import qualified "cryptonite" Crypto.KDF.PBKDF2 as PBKDF2
-
-import qualified "cryptonite" Crypto.PubKey.ECC.Types as ECC
-import qualified "cryptonite" Crypto.PubKey.ECC.Prim as ECC
-
-import Data.ByteArray (ByteArray)
-
+import           Data.ByteArray (ByteArray)
 import qualified Data.ByteString as B
+
+import Number.F2m
 
 benchHash =
     [ 
@@ -127,4 +126,5 @@ main = defaultMain
     , bgroup "AE" benchAE
     , bgroup "pbkdf2" benchPBKDF2
     , bgroup "ECC" benchECC
+    , bgroup "F2m" benchF2m
     ]

--- a/benchs/Number/F2m.hs
+++ b/benchs/Number/F2m.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE PackageImports #-}
 
-module Main where
+module Number.F2m (benchF2m) where
 
 import Criterion.Main
 import System.Random
 
-import "cryptonite" Crypto.Number.Basic (log2)
-import "cryptonite" Crypto.Number.F2m
+import Crypto.Number.Basic (log2)
+import Crypto.Number.F2m
 
 genInteger :: Int -> Int -> Integer
 genInteger salt bits
     = head
     . dropWhile ((< bits) . log2)
-    . scanl (\a r -> a * 2^31 + abs r) 0
+    . scanl (\a r -> a * 2^(31 :: Int) + abs r) 0
     . randoms
     . mkStdGen
     $ salt + bits
@@ -45,7 +45,7 @@ benchInv bits = bench (show bits) $ nf (invF2m m) a
 bitsList :: [Int]
 bitsList = [64, 128, 256, 512, 1024, 2048]
 
-main = defaultMain
+benchF2m =
     [ bgroup    "modF2m" $ map benchMod    bitsList
     , bgroup    "mulF2m" $ map benchMul    bitsList
     , bgroup "squareF2m" $ map benchSquare bitsList

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -382,3 +382,17 @@ Test-Suite test-cryptonite
                    , cryptonite
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures -fno-warn-unused-imports -rtsopts
   default-language:  Haskell2010
+
+Benchmark bench-cryptonite
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    benchs
+  Main-is:           Bench.hs
+  Other-modules:     Number.F2m
+  Build-Depends:     base >= 3 && < 5
+                   , bytestring
+                   , memory
+                   , criterion
+                   , random
+                   , cryptonite
+  ghc-options:       -Wall -fno-warn-missing-signatures
+  default-language:  Haskell2010


### PR DESCRIPTION
This adds benchmarks for the same list of algorithms than in the test suite.

I've selected a very small input size to test the overhead of the hash API itself and a larger size which should be more representative of the algorithms.
