### PR TITLE
Hash update

### DIFF
--- a/Crypto/Hash.hs
+++ b/Crypto/Hash.hs
@@ -17,6 +17,7 @@
 -- > hexSha3_512 bs = show (hash bs :: Digest SHA3_512)
 --
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns        #-}
 module Crypto.Hash
     (
     -- * Types

--- a/Crypto/Hash/Types.hs
+++ b/Crypto/Hash/Types.hs
@@ -18,6 +18,8 @@ import           Crypto.Internal.Imports
 import           Crypto.Internal.ByteArray (ByteArrayAccess, Bytes)
 import qualified Crypto.Internal.ByteArray as B
 import           Foreign.Ptr (Ptr)
+import qualified Foundation.Array as F
+import qualified Foundation       as F
 
 -- | Class representing hashing algorithms.
 --
@@ -50,8 +52,11 @@ newtype Context a = Context Bytes
     deriving (ByteArrayAccess,NFData)
 
 -- | Represent a digest for a given hash algorithm.
-newtype Digest a = Digest Bytes
-    deriving (Eq,Ord,ByteArrayAccess,NFData)
+newtype Digest a = Digest (F.UArray Word8)
+    deriving (Eq,Ord,ByteArrayAccess)
+
+instance NFData (Digest a) where
+    rnf (Digest u) = u `F.deepseq` ()
 
 instance Show (Digest a) where
     show (Digest bs) = map (toEnum . fromIntegral)

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -220,7 +220,8 @@ Library
                      Crypto.Internal.Nat
   Build-depends:     base >= 4.3 && < 5
                    , bytestring
-                   , memory >= 0.12
+                   , memory >= 0.14.4
+                   , foundation >= 0.0.8
                    , ghc-prim
   ghc-options:       -Wall -fwarn-tabs -optc-O3 -fno-warn-unused-imports
   default-language:  Haskell2010

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -220,7 +220,7 @@ Library
                      Crypto.Internal.Nat
   Build-depends:     base >= 4.3 && < 5
                    , bytestring
-                   , memory >= 0.14.4
+                   , memory >= 0.14.5
                    , foundation >= 0.0.8
                    , ghc-prim
   ghc-options:       -Wall -fwarn-tabs -optc-O3 -fno-warn-unused-imports


### PR DESCRIPTION
In application requiring to hold a lots of hash (cryptocurrencies, git, etc), the pin status of Digest make it to pin a lots of memory for something that should be really small.

Move to use Foundation UArray which have a pin-threshold-configurable binary representation