### PR TITLE
ed25519: Adding generateSecretKey and a unit test

### DIFF
--- a/tests/KAT_Ed25519.hs
+++ b/tests/KAT_Ed25519.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BangPatterns #-}
 module KAT_Ed25519 ( tests ) where
 
 import           Crypto.Error
@@ -23,6 +23,7 @@ vec1 = Vec
 testVec :: String -> Vec -> [TestTree]
 testVec s vec =
     [ testCase (s ++ " gen publickey") (pub @=? Ed25519.toPublic sec)
+    , testCase (s ++ " gen secretkey") (Ed25519.generateSecretKey *> pure ())
     , testCase (s ++ " gen signature") (sig @=? Ed25519.sign sec pub (vecMsg vec))
     ]
   where


### PR DESCRIPTION
This change adds a function for generating an Ed25519 secret key and exports the size constants for the `PublicKey`, `SecretKey`, and `Signature` for use with `getRandomBytes` and other functions.

The motivation for this change came from a CLI tool I wrote to generate an ed25519 key pair and sign and verify messages with ed25519 key pairs. I noticed Curve25519 had a generateSecretKey function but the ed25519 module did not so I wrote the code to generate it myself using `getRandomBytes`. I also goofed the first implementation by supplying a byte size to `getRandomBytes` that was greater than the number expected by the `Ed25519.secretKey` constructor so I attempted to use the `secretKeySize` function but it was not exported.

@vincenthz I noticed the `Curve25519.generateSecretKey` function modifies some of the generated random bytes; I don't understand the reason for it and instead of copying and pasting that code I figured I'd assume it was specific to `Curve25519` and leave it out and if that assumption is wrong, be schooled by you ;)