### PR TITLE
[ChaChaPoly1305] Add Eq and Ord instances for Nonce

### DIFF
--- a/Crypto/Cipher/ChaChaPoly1305.hs
+++ b/Crypto/Cipher/ChaChaPoly1305.hs
@@ -84,14 +84,12 @@ instance ByteArrayAccess Nonce where
 instance Eq Nonce where
   (Nonce8  a) == (Nonce8  b) = a == b
   (Nonce12 a) == (Nonce12 b) = a == b
-  (Nonce8  a) == (Nonce12 b) = a == b
-  (Nonce12 a) == (Nonce8  b) = a == b
+  _           == _           = error "unable to compare 8-byte and 12-byte nonces"
 
 instance Ord Nonce where
   compare (Nonce8  a) (Nonce8  b) = compare a b
   compare (Nonce12 a) (Nonce12 b) = compare a b
-  compare (Nonce8  a) (Nonce12 b) = compare a b
-  compare (Nonce12 a) (Nonce8  b) = compare a b
+  compare _           _           = error "unable to compare 8-byte and 12-byte nonces"
 
 -- Based on the following pseudo code:
 --

--- a/Crypto/Cipher/ChaChaPoly1305.hs
+++ b/Crypto/Cipher/ChaChaPoly1305.hs
@@ -81,6 +81,18 @@ instance ByteArrayAccess Nonce where
   withByteArray (Nonce8  n) = B.withByteArray n
   withByteArray (Nonce12 n) = B.withByteArray n
 
+instance Eq Nonce where
+  (Nonce8  a) == (Nonce8  b) = a == b
+  (Nonce12 a) == (Nonce12 b) = a == b
+  (Nonce8  a) == (Nonce12 b) = a == b
+  (Nonce12 a) == (Nonce8  b) = a == b
+
+instance Ord Nonce where
+  compare (Nonce8  a) (Nonce8  b) = compare a b
+  compare (Nonce12 a) (Nonce12 b) = compare a b
+  compare (Nonce8  a) (Nonce12 b) = compare a b
+  compare (Nonce12 a) (Nonce8  b) = compare a b
+
 -- Based on the following pseudo code:
 --
 -- chacha20_aead_encrypt(aad, key, iv, constant, plaintext):


### PR DESCRIPTION
The ability to compare Nonces is important because it allows you to detect when you reach the maximum nonce, thus preventing overflow resulting in catastrophic key re-use.