### PR TITLE
fix build failure with -f-support_deepseq disabled

### DIFF
--- a/Crypto/Internal/DeepSeq.hs
+++ b/Crypto/Internal/DeepSeq.hs
@@ -30,4 +30,6 @@ instance NFData Word64 where rnf w = w `seq` ()
 instance NFData Bytes where rnf b = b `seq` ()
 instance NFData ScrubbedBytes where rnf b = b `seq` ()
 
+instance NFData Integer  where rnf i = i `seq` ()
+
 #endif


### PR DESCRIPTION
How to reproduce:

```
$ cabal configure -f-support_deepseq
Resolving dependencies...
Configuring cryptonite-0.23...

$ cabal build
Building cryptonite-0.23...
Preprocessing library cryptonite-0.23...
[114 of 120] Compiling Crypto.PubKey.RSA.Types ( Crypto/PubKey/RSA/Types.hs, dist/build/Crypto/PubKey/RSA/Types

Crypto/PubKey/RSA/Types.hs:48:30: error:
    • No instance for (NFData Integer) arising from a use of ‘rnf’
    • In the first argument of ‘seq’, namely ‘rnf n’
      In the expression: rnf n `seq` rnf e `seq` sz `seq` ()
      In an equation for ‘rnf’:
          rnf (PublicKey sz n e) = rnf n `seq` rnf e `seq` sz `seq` ()
```

The fix is to inctoruce 'NFData Integer' instance to `Crypto/Internal/DeepSeq`.

Closes: https://github.com/haskell-crypto/cryptonite/issues/171
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>