### PR TITLE
Remove support_blake2_sse flag in favor of support_sse

### DIFF
--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -69,12 +69,7 @@ Flag support_pclmuldq
   Manual:            True
 
 Flag support_sse
-  Description:       Use SSE optimized version when existing (BLAKE2, ARGON2)
-  Default:           False
-  Manual:            True
-
-Flag support_blake2_sse
-  Description:       Use SSE optimized version of BLAKE2.
+  Description:       Use SSE optimized version of (BLAKE2, ARGON2)
   Default:           False
   Manual:            True
 
@@ -293,7 +288,7 @@ Library
                    , cbits/aes/gf.c
                    , cbits/cryptonite_aes.c
 
-  if arch(x86_64) || flag(support_blake2_sse)
+  if arch(x86_64) || flag(support_sse)
     C-sources:      cbits/blake2/sse/blake2s.c
                   , cbits/blake2/sse/blake2sp.c
                   , cbits/blake2/sse/blake2b.c


### PR DESCRIPTION
The description of the `support_sse` flag said, "Use SSE optimized version when existing (BLAKE2, ARGON2)", so I figured that at some point someone wanted to have this done.