### PR TITLE
Actually process unaligned data through trampoline buffer

### DIFF
--- a/cbits/cryptonite_sha3.c
+++ b/cbits/cryptonite_sha3.c
@@ -135,8 +135,8 @@ void cryptonite_sha3_update(struct sha3_ctx *ctx, const uint8_t *data, uint32_t 
 		uint64_t tramp[SHA3_BUF_SIZE_MAX/8];
 		ASSERT_ALIGNMENT(tramp, 8);
 		for (; len >= ctx->bufsz; len -= ctx->bufsz, data += ctx->bufsz) {
-			memcpy(tramp, data, ctx->bufsz / 8);
-			sha3_do_chunk(ctx->state, (uint64_t *) data, ctx->bufsz / 8);
+			memcpy(tramp, data, ctx->bufsz);
+			sha3_do_chunk(ctx->state, tramp, ctx->bufsz / 8);
 		}
 	} else {
 		/* process as much ctx->bufsz-block */


### PR DESCRIPTION
Follow-on to commit ba10930, which implemented a trampoline buffer but then
used the unaligned input character array instead.  This commit /actually/
fixes #108, having been tested on an affected architecture :)