### PR TITLE
Fix many cases of unaligned accesses

### DIFF
--- a/cbits/cryptonite_poly1305.c
+++ b/cbits/cryptonite_poly1305.c
@@ -37,11 +37,7 @@
 #include <string.h>
 #include "cryptonite_poly1305.h"
 #include "cryptonite_bitfn.h"
-
-static inline uint32_t load32(uint8_t *p)
-{
-	return (le32_to_cpu(*((uint32_t *) p)));
-}
+#include "cryptonite_align.h"
 
 static void poly1305_do_chunk(poly1305_ctx *ctx, uint8_t *data, int blocks, int final)
 {
@@ -61,11 +57,11 @@ static void poly1305_do_chunk(poly1305_ctx *ctx, uint8_t *data, int blocks, int 
 	s1 = r1 * 5; s2 = r2 * 5; s3 = r3 * 5; s4 = r4 * 5;
 
 	while (blocks--) {
-		h0 += (load32(data+ 0)     ) & 0x3ffffff;
-		h1 += (load32(data+ 3) >> 2) & 0x3ffffff;
-		h2 += (load32(data+ 6) >> 4) & 0x3ffffff;
-		h3 += (load32(data+ 9) >> 6) & 0x3ffffff;
-		h4 += (load32(data+12) >> 8) | hibit;
+		h0 += (load_le32(data+ 0)     ) & 0x3ffffff;
+		h1 += (load_le32(data+ 3) >> 2) & 0x3ffffff;
+		h2 += (load_le32(data+ 6) >> 4) & 0x3ffffff;
+		h3 += (load_le32(data+ 9) >> 6) & 0x3ffffff;
+		h4 += (load_le32(data+12) >> 8) | hibit;
 
 		d0 = ((uint64_t)h0 * r0) + ((uint64_t)h1 * s4) + ((uint64_t)h2 * s3) + ((uint64_t)h3 * s2) + ((uint64_t)h4 * s1);
 		d1 = ((uint64_t)h0 * r1) + ((uint64_t)h1 * r0) + ((uint64_t)h2 * s4) + ((uint64_t)h3 * s3) + ((uint64_t)h4 * s2);
@@ -94,16 +90,16 @@ void cryptonite_poly1305_init(poly1305_ctx *ctx, poly1305_key *key)
 
 	memset(ctx, 0, sizeof(poly1305_ctx));
 
-	ctx->r[0] = (load32(&k[ 0])     ) & 0x3ffffff;
-	ctx->r[1] = (load32(&k[ 3]) >> 2) & 0x3ffff03;
-	ctx->r[2] = (load32(&k[ 6]) >> 4) & 0x3ffc0ff;
-	ctx->r[3] = (load32(&k[ 9]) >> 6) & 0x3f03fff;
-	ctx->r[4] = (load32(&k[12]) >> 8) & 0x00fffff;
+	ctx->r[0] = (load_le32(&k[ 0])     ) & 0x3ffffff;
+	ctx->r[1] = (load_le32(&k[ 3]) >> 2) & 0x3ffff03;
+	ctx->r[2] = (load_le32(&k[ 6]) >> 4) & 0x3ffc0ff;
+	ctx->r[3] = (load_le32(&k[ 9]) >> 6) & 0x3f03fff;
+	ctx->r[4] = (load_le32(&k[12]) >> 8) & 0x00fffff;
 
-	ctx->pad[0] = load32(&k[16]);
-	ctx->pad[1] = load32(&k[20]);
-	ctx->pad[2] = load32(&k[24]);
-	ctx->pad[3] = load32(&k[28]);
+	ctx->pad[0] = load_le32(&k[16]);
+	ctx->pad[1] = load_le32(&k[20]);
+	ctx->pad[2] = load_le32(&k[24]);
+	ctx->pad[3] = load_le32(&k[28]);
 
 	ctx->index = 0;
 }

--- a/cbits/cryptonite_salsa.c
+++ b/cbits/cryptonite_salsa.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include "cryptonite_salsa.h"
 #include "cryptonite_bitfn.h"
+#include "cryptonite_align.h"
 
 static const uint8_t sigma[16] = "expand 32-byte k";
 static const uint8_t tau[16] = "expand 16-byte k";
@@ -57,11 +58,6 @@ static const uint8_t tau[16] = "expand 16-byte k";
 		QR (x10,x11,x8,x9); \
 		QR (x15,x12,x13,x14); \
 	}
-
-static inline uint32_t load32(const uint8_t *p)
-{
-	return le32_to_cpu(*((uint32_t *) p));
-}
 
 static void salsa_core(int rounds, block *out, const cryptonite_salsa_state *in)
 {
@@ -126,34 +122,34 @@ void cryptonite_salsa_init_core(cryptonite_salsa_state *st,
 	const uint8_t *constants = (keylen == 32) ? sigma : tau;
 	int i;
 
-	st->d[0] = load32(constants + 0);
-	st->d[5] = load32(constants + 4);
-	st->d[10] = load32(constants + 8);
-	st->d[15] = load32(constants + 12);
+	st->d[0] = load_le32_aligned(constants + 0);
+	st->d[5] = load_le32_aligned(constants + 4);
+	st->d[10] = load_le32_aligned(constants + 8);
+	st->d[15] = load_le32_aligned(constants + 12);
 
-	st->d[1] = load32(key + 0);
-	st->d[2] = load32(key + 4);
-	st->d[3] = load32(key + 8);
-	st->d[4] = load32(key + 12);
+	st->d[1] = load_le32(key + 0);
+	st->d[2] = load_le32(key + 4);
+	st->d[3] = load_le32(key + 8);
+	st->d[4] = load_le32(key + 12);
 	/* we repeat the key on 128 bits */
 	if (keylen == 32)
 		key += 16;
-	st->d[11] = load32(key + 0);
-	st->d[12] = load32(key + 4);
-	st->d[13] = load32(key + 8);
-	st->d[14] = load32(key + 12);
+	st->d[11] = load_le32(key + 0);
+	st->d[12] = load_le32(key + 4);
+	st->d[13] = load_le32(key + 8);
+	st->d[14] = load_le32(key + 12);
 
 	st->d[9] = 0;
 	switch (ivlen) {
 	case 8:
-		st->d[6] = load32(iv + 0);
-		st->d[7] = load32(iv + 4);
+		st->d[6] = load_le32(iv + 0);
+		st->d[7] = load_le32(iv + 4);
 		st->d[8] = 0;
 		break;
 	case 12:
-		st->d[6] = load32(iv + 0);
-		st->d[7] = load32(iv + 4);
-		st->d[8] = load32(iv + 8);
+		st->d[6] = load_le32(iv + 0);
+		st->d[7] = load_le32(iv + 4);
+		st->d[8] = load_le32(iv + 8);
 	default:
 		return;
 	}

--- a/cbits/cryptonite_scrypt.c
+++ b/cbits/cryptonite_scrypt.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "cryptonite_bitfn.h"
+#include "cryptonite_align.h"
 #include "cryptonite_salsa.h"
 
 static void blockmix_salsa8(uint32_t *in, uint32_t *out, uint32_t *X, const uint32_t r)
@@ -49,16 +50,6 @@ static inline uint64_t integerify(uint32_t *B, const uint32_t r)
 	return B[(2*r-1) * 16] | (uint64_t)B[(2*r-1) * 16 + 1] << 32;
 }
 
-static inline uint32_t load32(const uint8_t *p)
-{
-	return le32_to_cpu(*((uint32_t *) p));
-}
-
-static inline void store32(const uint8_t *p, uint32_t val)
-{
-	*((uint32_t *) p) = cpu_to_le32(val);
-}
-
 void cryptonite_scrypt_smix(uint8_t *B, const uint32_t r, const uint64_t N, uint32_t *V, uint32_t *XY)
 {
 	uint32_t *X = XY;
@@ -69,7 +60,7 @@ void cryptonite_scrypt_smix(uint8_t *B, const uint32_t r, const uint64_t N, uint
 	const int r32 = 32*r;
 
 	for (k = 0; k < r32; k++)
-		X[k] = load32(&B[4 * k]);
+		X[k] = load_le32_aligned(&B[4 * k]);
 	for (i = 0; i < N; i += 2) {
 		array_copy32(&V[i * r32], X, r32);
 		blockmix_salsa8(X, Y, Z, r);
@@ -86,5 +77,5 @@ void cryptonite_scrypt_smix(uint8_t *B, const uint32_t r, const uint64_t N, uint
 		blockmix_salsa8(Y, X, Z, r);
 	}
 	for (k = 0; k < r32; k++)
-		store32(&B[4*k], X[k]);
+		store_le32_aligned(&B[4*k], X[k]);
 }

--- a/cbits/cryptonite_sha1.c
+++ b/cbits/cryptonite_sha1.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include "cryptonite_sha1.h"
 #include "cryptonite_bitfn.h"
+#include "cryptonite_align.h"
 
 void cryptonite_sha1_init(struct sha1_ctx *ctx)
 {
@@ -173,9 +174,18 @@ void cryptonite_sha1_update(struct sha1_ctx *ctx, const uint8_t *data, uint32_t 
 		index = 0;
 	}
 
-	/* process as much 64-block as possible */
-	for (; len >= 64; len -= 64, data += 64)
-		sha1_do_chunk(ctx, (uint32_t *) data);
+	if (need_alignment(data, 4)) {
+		uint32_t tramp[16];
+		ASSERT_ALIGNMENT(tramp, 4);
+		for (; len >= 64; len -= 64, data += 64) {
+			memcpy(tramp, data, 64);
+			sha1_do_chunk(ctx, tramp);
+		}
+	} else {
+		/* process as much 64-block as possible */
+		for (; len >= 64; len -= 64, data += 64)
+			sha1_do_chunk(ctx, (uint32_t *) data);
+	}
 
 	/* append data into buf */
 	if (len)
@@ -187,7 +197,6 @@ void cryptonite_sha1_finalize(struct sha1_ctx *ctx, uint8_t *out)
 	static uint8_t padding[64] = { 0x80, };
 	uint64_t bits;
 	uint32_t index, padlen;
-	uint32_t *p = (uint32_t *) out;
 
 	/* add padding and update data with it */
 	bits = cpu_to_be64(ctx->sz << 3);
@@ -201,9 +210,9 @@ void cryptonite_sha1_finalize(struct sha1_ctx *ctx, uint8_t *out)
 	cryptonite_sha1_update(ctx, (uint8_t *) &bits, sizeof(bits));
 
 	/* output hash */
-	p[0] = cpu_to_be32(ctx->h[0]);
-	p[1] = cpu_to_be32(ctx->h[1]);
-	p[2] = cpu_to_be32(ctx->h[2]);
-	p[3] = cpu_to_be32(ctx->h[3]);
-	p[4] = cpu_to_be32(ctx->h[4]);
+	store_be32(out   , ctx->h[0]);
+	store_be32(out+ 4, ctx->h[1]);
+	store_be32(out+ 8, ctx->h[2]);
+	store_be32(out+12, ctx->h[3]);
+	store_be32(out+16, ctx->h[4]);
 }

--- a/cbits/cryptonite_xsalsa.c
+++ b/cbits/cryptonite_xsalsa.c
@@ -30,12 +30,8 @@
 #include <stdint.h>
 #include <string.h>
 #include "cryptonite_xsalsa.h"
+#include "cryptonite_align.h"
 #include "cryptonite_bitfn.h"
-
-static inline uint32_t load32(const uint8_t *p)
-{
-  return le32_to_cpu(*((uint32_t *) p));
-}
 
 /* XSalsa20 algorithm as described in https://cr.yp.to/snuffle/xsalsa-20081128.pdf */
 void cryptonite_xsalsa_init(cryptonite_salsa_context *ctx, uint8_t nb_rounds,
@@ -51,8 +47,8 @@ void cryptonite_xsalsa_init(cryptonite_salsa_context *ctx, uint8_t nb_rounds,
        (x6, x7, x8, x9) is the first 128 bits of a 192-bit nonce
   */
   cryptonite_salsa_init_core(&ctx->st, keylen, key, 8, iv);
-  ctx->st.d[ 8] = load32(iv + 8);
-  ctx->st.d[ 9] = load32(iv + 12);
+  ctx->st.d[ 8] = load_le32(iv + 8);
+  ctx->st.d[ 9] = load_le32(iv + 12);
 
   /* Compute (z0, z1, . . . , z15) = doubleround ^(r/2) (x0, x1, . . . , x15) */
   block hSalsa;
@@ -73,8 +69,8 @@ void cryptonite_xsalsa_init(cryptonite_salsa_context *ctx, uint8_t nb_rounds,
   ctx->st.d[12] = hSalsa.d[ 7] - ctx->st.d[ 7];
   ctx->st.d[13] = hSalsa.d[ 8] - ctx->st.d[ 8];
   ctx->st.d[14] = hSalsa.d[ 9] - ctx->st.d[ 9];
-  ctx->st.d[ 6] = load32(iv + 16);
-  ctx->st.d[ 7] = load32(iv + 20);
+  ctx->st.d[ 6] = load_le32(iv + 16);
+  ctx->st.d[ 7] = load_le32(iv + 20);
   ctx->st.d[ 8] = 0;
   ctx->st.d[ 9] = 0;
 }


### PR DESCRIPTION
This is a second attempt at #110 which I have finally had a chance to do. The AES block128 changes feel slightly unsatisfactory, but copying to temporary buffers would be far more invasive, given the number of different variations, and my guess is that most of the operations are acting on either the input or output and thus could be unaligned. Since on x86 need_alignment is the constant 0, the compiler should be able to optimise away the if statement and with sufficient inlining be as efficient as before, but I haven't actually checked this. If you would prefer to also add an extra `#ifdef UNALIGNED_ACCESS_OK` check to define the block128 functions to their aligned versions I can do that, but that's more code, and I hope it's not needed.