### PR TITLE
Validate result of P256.pointFromBinary and EllipticCurveDH.ecdh

### DIFF
--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -81,7 +81,21 @@ class EllipticCurve curve => EllipticCurveDH curve where
     -- is not hashed.
     --
     -- use `pointSmul` to keep the result in Point format.
-    ecdh :: proxy curve -> Scalar curve -> Point curve -> SharedSecret
+    --
+    -- /WARNING:/ Curve implementations may return a special value or an
+    -- exception when the public point lies in a subgroup of small order.
+    -- This function is adequate when the scalar is in expected range and
+    -- contributory behaviour is not needed.  Otherwise use 'ecdh'.
+    ecdhRaw :: proxy curve -> Scalar curve -> Point curve -> SharedSecret
+    ecdhRaw prx s = throwCryptoError . ecdh prx s
+
+    -- | Generate a Diffie hellman secret value and verify that the result
+    -- is not the point at infinity.
+    --
+    -- This additional test avoids risks existing with function 'ecdhRaw'.
+    -- Implementations always return a 'CryptoError' instead of a special
+    -- value or an exception.
+    ecdh :: proxy curve -> Scalar curve -> Point curve -> CryptoFailable SharedSecret
 
 class EllipticCurve curve => EllipticCurveArith curve where
     -- | Add points on a curve
@@ -126,7 +140,8 @@ instance EllipticCurveArith Curve_P256R1 where
     pointSmul _ s p = P256.pointMul s p
 
 instance EllipticCurveDH Curve_P256R1 where
-    ecdh _ s p = SharedSecret $ P256.pointDh s p
+    ecdhRaw _ s p = SharedSecret $ P256.pointDh s p
+    ecdh  prx s p = checkNonZeroDH (ecdhRaw prx s p)
 
 data Curve_P384R1 = Curve_P384R1
     deriving (Show,Data,Typeable)
@@ -146,10 +161,9 @@ instance EllipticCurveArith Curve_P384R1 where
     pointSmul _ s p = Simple.pointMul s p
 
 instance EllipticCurveDH Curve_P384R1 where
-    ecdh _ s p = SharedSecret $ i2ospOf_ (curveSizeBytes prx) x
+    ecdh _ s p = encodeECShared prx (Simple.pointMul s p)
       where
-        prx = Proxy :: Proxy Curve_P384R1
-        Simple.Point x _ = pointSmul prx s p
+        prx = Proxy :: Proxy Simple.SEC_p384r1
 
 data Curve_P521R1 = Curve_P521R1
     deriving (Show,Data,Typeable)
@@ -169,10 +183,9 @@ instance EllipticCurveArith Curve_P521R1 where
     pointSmul _ s p = Simple.pointMul s p
 
 instance EllipticCurveDH Curve_P521R1 where
-    ecdh _ s p = SharedSecret $ i2ospOf_ (curveSizeBytes prx) x
+    ecdh _ s p = encodeECShared prx (Simple.pointMul s p)
       where
-        prx = Proxy :: Proxy Curve_P521R1
-        Simple.Point x _ = pointSmul prx s p
+        prx = Proxy :: Proxy Simple.SEC_p521r1
 
 data Curve_X25519 = Curve_X25519
     deriving (Show,Data,Typeable)
@@ -189,8 +202,9 @@ instance EllipticCurve Curve_X25519 where
     decodePoint _ bs = X25519.publicKey bs
 
 instance EllipticCurveDH Curve_X25519 where
-    ecdh _ s p = SharedSecret $ convert secret
+    ecdhRaw _ s p = SharedSecret $ convert secret
       where secret = X25519.dh p s
+    ecdh prx s p = checkNonZeroDH (ecdhRaw prx s p)
 
 data Curve_X448 = Curve_X448
     deriving (Show,Data,Typeable)
@@ -207,8 +221,18 @@ instance EllipticCurve Curve_X448 where
     decodePoint _ bs = X448.publicKey bs
 
 instance EllipticCurveDH Curve_X448 where
-    ecdh _ s p = SharedSecret $ convert secret
+    ecdhRaw _ s p = SharedSecret $ convert secret
       where secret = X448.dh p s
+    ecdh prx s p = checkNonZeroDH (ecdhRaw prx s p)
+
+checkNonZeroDH :: SharedSecret -> CryptoFailable SharedSecret
+checkNonZeroDH s@(SharedSecret b)
+    | B.constAllZero b = CryptoFailed CryptoError_ScalarMultiplicationInvalid
+    | otherwise        = CryptoPassed s
+
+encodeECShared :: Simple.Curve curve => Proxy curve -> Simple.Point curve -> CryptoFailable SharedSecret
+encodeECShared _   Simple.PointO      = CryptoFailed CryptoError_ScalarMultiplicationInvalid
+encodeECShared prx (Simple.Point x _) = CryptoPassed . SharedSecret $ i2ospOf_ (Simple.curveSizeBytes prx) x
 
 encodeECPoint :: forall curve bs . (Simple.Curve curve, ByteArray bs) => Simple.Point curve -> bs
 encodeECPoint Simple.PointO      = error "encodeECPoint: cannot serialize point at infinity"
@@ -232,6 +256,3 @@ decodeECPoint mxy = case B.uncons mxy of
                 y = os2ip yb
              in Simple.pointFromIntegers (x,y)
         | otherwise -> CryptoFailed $ CryptoError_PointFormatInvalid
-
-curveSizeBytes :: EllipticCurve c => Proxy c -> Int
-curveSizeBytes proxy = (curveSizeBits proxy + 7) `div` 8

--- a/Crypto/ECC.hs
+++ b/Crypto/ECC.hs
@@ -118,7 +118,7 @@ instance EllipticCurve Curve_P256R1 where
         Nothing -> CryptoFailed $ CryptoError_PointSizeInvalid
         Just (m,xy)
             -- uncompressed
-            | m == 4 -> P256.pointFromBinary xy >>= validateP256Point
+            | m == 4 -> P256.pointFromBinary xy
             | otherwise -> CryptoFailed $ CryptoError_PointFormatInvalid
 
 instance EllipticCurveArith Curve_P256R1 where
@@ -209,11 +209,6 @@ instance EllipticCurve Curve_X448 where
 instance EllipticCurveDH Curve_X448 where
     ecdh _ s p = SharedSecret $ convert secret
       where secret = X448.dh p s
-
-validateP256Point :: P256.Point -> CryptoFailable P256.Point
-validateP256Point p
-    | P256.pointIsValid p = CryptoPassed p
-    | otherwise           = CryptoFailed $ CryptoError_PointCoordinatesInvalid
 
 encodeECPoint :: forall curve bs . (Simple.Curve curve, ByteArray bs) => Simple.Point curve -> bs
 encodeECPoint Simple.PointO      = error "encodeECPoint: cannot serialize point at infinity"

--- a/Crypto/Error/Types.hs
+++ b/Crypto/Error/Types.hs
@@ -40,6 +40,7 @@ data CryptoError =
     | CryptoError_PointFormatInvalid
     | CryptoError_PointFormatUnsupported
     | CryptoError_PointCoordinatesInvalid
+    | CryptoError_ScalarMultiplicationInvalid
     -- Message authentification error
     | CryptoError_MacKeyInvalid
     | CryptoError_AuthenticationTagSizeInvalid

--- a/Crypto/Internal/ByteArray.hs
+++ b/Crypto/Internal/ByteArray.hs
@@ -7,13 +7,33 @@
 --
 -- Simple and efficient byte array types
 --
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Crypto.Internal.ByteArray
     ( module Data.ByteArray
     , module Data.ByteArray.Mapping
     , module Data.ByteArray.Encoding
+    , constAllZero
     ) where
 
 import Data.ByteArray
 import Data.ByteArray.Mapping
 import Data.ByteArray.Encoding
+
+import Data.Bits ((.|.))
+import Data.Word (Word8)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (peekByteOff)
+
+import Crypto.Internal.Compat (unsafeDoIO)
+
+constAllZero :: ByteArrayAccess ba => ba -> Bool
+constAllZero b = unsafeDoIO $ withByteArray b $ \p -> loop p 0 0
+  where
+    loop :: Ptr b -> Int -> Word8 -> IO Bool
+    loop p i !acc
+        | i == len  = return $! acc == 0
+        | otherwise = do
+            e <- peekByteOff p i
+            loop p (i+1) (acc .|. e)
+    len = Data.ByteArray.length b

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -114,7 +114,8 @@ pointMul scalar p = withNewPoint $ \dx dy ->
     withScalar scalar $ \n -> withPoint p $ \px py -> withScalarZero $ \nzero ->
         ccryptonite_p256_points_mul_vartime nzero n px py dx dy
 
--- | Similar to 'pointMul', serializing the x coordinate as binary
+-- | Similar to 'pointMul', serializing the x coordinate as binary.
+-- When scalar is multiple of point order the result is all zero.
 pointDh :: ByteArray binary => Scalar -> Point -> binary
 pointDh scalar p =
     B.unsafeCreate scalarSize $ \dst -> withTempPoint $ \dx dy -> do

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -97,7 +97,7 @@ tests = testGroup "P256"
         [ testProperty "marshalling" $ \rx ry ->
             let p = P256.pointFromIntegers (unP256 rx, unP256 ry)
                 b = P256.pointToBinary p :: Bytes
-                p' = P256.pointFromBinary b
+                p' = P256.unsafePointFromBinary b
              in propertyHold [ eqTest "point" (CryptoPassed p) p' ]
         , testProperty "marshalling-integer" $ \rx ry ->
             let p = P256.pointFromIntegers (unP256 rx, unP256 ry)


### PR DESCRIPTION
This PR:
- changes API so that class EllipticCurveDH and module ECIES can return failures (stricter validation explained in #178)
- adds point validation directly in P256.pointFromBinary (discussed in #168)
