### PR TITLE
Link against pthread on Linux to support gold linker

### DIFF
--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -226,6 +226,8 @@ Library
                    , foundation >= 0.0.8
                    , ghc-prim
   ghc-options:       -Wall -fwarn-tabs -optc-O3 -fno-warn-unused-imports
+  if os(linux)
+    extra-libraries: pthread
   default-language:  Haskell2010
   cc-options:        -std=gnu99
   if flag(old_toolchain_inliner)


### PR DESCRIPTION
Since we're using `pthread_join` and `pthread_create`,
to make the gold linker happy on linux we need to explicitly
link against `pthread` library.

Somewhat similar change was done to upstream `base` library and its `m` dependency: https://phabricator.haskell.org/D3787

You can see a build failing without this fix: https://hydra.iohk.io/log/v10g61l4si5qq2v5zqm8mq1dak65i60d-cardano-sl-0.5.1.drv

And once cryptonite is bumped (https://github.com/input-output-hk/iohk-ops/pull/118/files) it compiles again: https://hydra.iohk.io/build/13093/nixlog/3/tail

cc @vincenthz 