### PR TITLE
prefer /dev/urandom over /dev/random

### DIFF
--- a/Crypto/Random/Entropy/Backend.hs
+++ b/Crypto/Random/Entropy/Backend.hs
@@ -35,7 +35,7 @@ supportedBackends =
 #ifdef WINDOWS
     openBackend (undefined :: WinCryptoAPI)
 #else
-    openBackend (undefined :: DevRandom), openBackend (undefined :: DevURandom)
+    openBackend (undefined :: DevURandom), openBackend (undefined :: DevRandom)
 #endif
     ]
 


### PR DESCRIPTION
On Unix machines it is in general preferable to use `/dev/urandom` instead of `/dev/random`. If I understand the code correctly this one line patch will do the necessary.