### PR TITLE
Use Proxy for openBackend

### DIFF
--- a/Crypto/Random/Entropy/Backend.hs
+++ b/Crypto/Random/Entropy/Backend.hs
@@ -15,6 +15,7 @@ module Crypto.Random.Entropy.Backend
 
 import Foreign.Ptr
 import Data.Word (Word8)
+import Crypto.Internal.Proxy
 import Crypto.Random.Entropy.Source
 #ifdef SUPPORT_RDRAND
 import Crypto.Random.Entropy.RDRand
@@ -30,12 +31,12 @@ supportedBackends :: [IO (Maybe EntropyBackend)]
 supportedBackends =
     [
 #ifdef SUPPORT_RDRAND
-    openBackend (undefined :: RDRand),
+    openBackend (Proxy :: Proxy RDRand),
 #endif
 #ifdef WINDOWS
-    openBackend (undefined :: WinCryptoAPI)
+    openBackend (Proxy :: Proxy WinCryptoAPI)
 #else
-    openBackend (undefined :: DevRandom), openBackend (undefined :: DevURandom)
+    openBackend (Proxy :: Proxy DevRandom), openBackend (Proxy :: Proxy DevURandom)
 #endif
     ]
 
@@ -43,9 +44,9 @@ supportedBackends =
 data EntropyBackend = forall b . EntropySource b => EntropyBackend b
 
 -- | Open a backend handle
-openBackend :: EntropySource b => b -> IO (Maybe EntropyBackend)
+openBackend :: EntropySource b => Proxy b -> IO (Maybe EntropyBackend)
 openBackend b = fmap EntropyBackend `fmap` callOpen b
-  where callOpen :: EntropySource b => b -> IO (Maybe b)
+  where callOpen :: EntropySource b => Proxy b -> IO (Maybe b)
         callOpen _ = entropyOpen
 
 -- | Gather randomness from an open handle

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -224,7 +224,7 @@ Library
     Other-modules:   Crypto.Hash.SHAKE
                      Crypto.Hash.Blake2
                      Crypto.Internal.Nat
-  Build-depends:     base >= 4.3 && < 5
+  Build-depends:     base >= 4.6 && < 5
                    , bytestring
                    , memory >= 0.14.5
                    , foundation >= 0.0.8


### PR DESCRIPTION
Project still works with GHC 7.6 but with the Proxy compatibility module it's easy to replace `undefined`.

We can also bump `base` to 4.6 minimum after #182.