### PR TITLE
add instance of MonadFailure to CryptoFailable

### DIFF
--- a/Crypto/Error/Types.hs
+++ b/Crypto/Error/Types.hs
@@ -8,6 +8,7 @@
 -- Cryptographic Error enumeration and handling
 --
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TypeFamilies       #-}
 module Crypto.Error.Types
     ( CryptoError(..)
     , CryptoFailable(..)
@@ -21,6 +22,7 @@ module Crypto.Error.Types
 import qualified Control.Exception as E
 import           Data.Data
 
+import           Foundation.Monad (MonadFailure(..))
 import           Crypto.Internal.Imports
 
 -- | Enumeration of all possible errors that can be found in this library
@@ -86,6 +88,10 @@ instance Monad CryptoFailable where
         case m1 of
             CryptoPassed a -> m2 a
             CryptoFailed e -> CryptoFailed e
+
+instance MonadFailure CryptoFailable where
+    type Failure CryptoFailable = CryptoError
+    mFail = CryptoFailed
 
 -- | Throw an CryptoError as exception on CryptoFailed result,
 -- otherwise return the computed value


### PR DESCRIPTION
This will make it more convenient to interact with foundation's types (like [`Conduit`](https://www.stackage.org/haddock/lts-9.13/foundation-0.0.17/Foundation-Conduit.html#t:Conduit) )