### PR TITLE
withDev: Close the FD on exception

### DIFF
--- a/Crypto/Random/Entropy/Unix.hs
+++ b/Crypto/Random/Entropy/Unix.hs
@@ -58,7 +58,7 @@ withDev :: String -> (H -> IO a) -> IO a
 withDev filepath f = openDev filepath >>= \h ->
     case h of
         Nothing -> error ("device " ++ filepath ++ " cannot be grabbed")
-        Just fd -> f fd >>= \r -> (closeDev fd >> return r)
+        Just fd -> f fd `E.finally` closeDev fd
 
 closeDev :: H -> IO ()
 closeDev h = hClose h


### PR DESCRIPTION
Currently I think it's very _unlikely_ but _possible_ to have fd leaks: `withDev`
is called with two arguments: `gatherDevEntropy` and
`gatherDevEntropyNonBlock`. Both handle `IOException`s, but it's possible that
the thread gets an async exception, which is not handled and causes `withDev` to
leak the fd.

With this PR `withDev` closes the fd in all cases.