### PR TITLE
byteStringFromDigest defined

### DIFF
--- a/Crypto/Hash.hs
+++ b/Crypto/Hash.hs
@@ -26,8 +26,6 @@ module Crypto.Hash
     -- * Functions
     , digestFromByteString
     , byteStringFromDigest
-    , byteStringFromDigest'
-    , byteStringFromDigest''
     -- * Hash methods parametrized by algorithm
     , hashInitWith
     , hashWith
@@ -129,21 +127,11 @@ digestFromByteString = from undefined
             unsafeFreeze muArray
           where
             count = CountOf (B.length ba)
+{-# INLINABLE digestFromByteString #-}
 
--- | Inefficient version.
+-- | Get the bytes of a Digest.
 byteStringFromDigest :: forall a ba . (ByteArray ba) => Digest a -> ba
-byteStringFromDigest = B.convert
-{-# INLINABLE byteStringFromDigest #-}
-
--- | Very fast version.
-byteStringFromDigest' :: forall a . Digest a -> ByteString
-byteStringFromDigest' (Digest uarray@(UArray _ (CountOf size) _)) = unsafeDoIO $
-    BS.create size (UA.copyToPtr uarray)
-{-# INLINABLE byteStringFromDigest' #-}
-
--- | General version which is good but not as good as 'byteStringFromDigest''
-byteStringFromDigest'' :: forall a ba . (ByteArray ba) => Digest a -> ba
-byteStringFromDigest'' (Digest uarray@(UArray _ (CountOf size) _)) = unsafeDoIO $ do
+byteStringFromDigest (Digest uarray@(UArray _ (CountOf size) _)) = unsafeDoIO $ do
     (_, ba) <- B.allocRet size (B.copyByteArrayToPtr uarray)
     return ba
-{-# INLINABLE byteStringFromDigest'' #-}
+{-# INLINABLE byteStringFromDigest #-}

--- a/Crypto/Hash.hs
+++ b/Crypto/Hash.hs
@@ -133,14 +133,17 @@ digestFromByteString = from undefined
 -- | Inefficient version.
 byteStringFromDigest :: forall a ba . (ByteArray ba) => Digest a -> ba
 byteStringFromDigest = B.convert
+{-# INLINABLE byteStringFromDigest #-}
 
 -- | Very fast version.
 byteStringFromDigest' :: forall a . Digest a -> ByteString
 byteStringFromDigest' (Digest uarray@(UArray _ (CountOf size) _)) = unsafeDoIO $
-    BS.create size $ \bsPtr -> UA.copyToPtr uarray bsPtr
+    BS.create size (UA.copyToPtr uarray)
+{-# INLINABLE byteStringFromDigest' #-}
 
 -- | General version which is good but not as good as 'byteStringFromDigest''
 byteStringFromDigest'' :: forall a ba . (ByteArray ba) => Digest a -> ba
 byteStringFromDigest'' (Digest uarray@(UArray _ (CountOf size) _)) = unsafeDoIO $ do
-    (_, ba) <- B.allocRet size $ \ptr -> UA.copyToPtr uarray ptr
+    (_, ba) <- B.allocRet size (B.copyByteArrayToPtr uarray)
     return ba
+{-# INLINABLE byteStringFromDigest'' #-}

--- a/Crypto/Hash.hs
+++ b/Crypto/Hash.hs
@@ -26,7 +26,6 @@ module Crypto.Hash
     -- * Functions
     , digestFromByteString
     , byteStringFromDigest
-    , convertByteStringFromDigest
     -- * Hash methods parametrized by algorithm
     , hashInitWith
     , hashWith
@@ -131,16 +130,5 @@ digestFromByteString = from undefined
 {-# INLINABLE digestFromByteString #-}
 
 byteStringFromDigest :: forall a ba . (ByteArray ba) => Digest a -> ba
-byteStringFromDigest digest = unsafeDoIO $ do
-    (_, ba) <- B.allocRet (B.length digest) (B.copyByteArrayToPtr digest)
-    return ba
+byteStringFromDigest = B.convert
 {-# INLINABLE byteStringFromDigest #-}
-
-convertByteStringFromDigest :: forall a ba . (ByteArray ba) => Digest a -> ba
-convertByteStringFromDigest digest = unsafeDoIO (go (B.length digest))
-  where
-    go sz | sz < 0 = go 0
-          | otherwise = fmap snd $ B.allocRet sz $ \d -> do
-                            B.copyByteArrayToPtr digest d
-                            (\_ -> return ()) (castPtr d)
-{-# INLINABLE convertByteStringFromDigest #-}


### PR DESCRIPTION
AFAIK the standard way to get a `ByteString` from a `Digest h` is to use `ByteArray.convert`, but that's not so efficient. `byteStringFromDigest` is defined here, in 3 different ways. The specialized `byteStringFromDigest' :: Digest h -> ByteString` is fastest, but we believe it should be possible to get a `byteStringFromDigest'' :: ByteArray ba => Digest h -> ba` which is just as good.
  
Follow up to #210 