### PR TITLE
ECDSA with a type class

### DIFF
--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -244,34 +244,21 @@ scalarIsZero s = unsafeDoIO $ withScalar s $ \d -> do
     result <- ccryptonite_p256_is_zero d
     return $ result /= 0
 
-scalarNeedReducing :: Ptr P256Scalar -> IO Bool
-scalarNeedReducing d = do
-    c <- ccryptonite_p256_cmp d ccryptonite_SECP256r1_n
-    return (c >= 0)
-
 -- | Perform addition between two scalars
 --
 -- > a + b
 scalarAdd :: Scalar -> Scalar -> Scalar
 scalarAdd a b =
-    withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb -> do
-        carry <- ccryptonite_p256_add pa pb d
-        when (carry /= 0) $ void $ ccryptonite_p256_sub d ccryptonite_SECP256r1_n d
-        needReducing <- scalarNeedReducing d
-        when needReducing $ do
-            ccryptonite_p256_mod ccryptonite_SECP256r1_n d d
+    withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb ->
+        ccryptonite_p256e_modadd ccryptonite_SECP256r1_n pa pb d
 
 -- | Perform subtraction between two scalars
 --
 -- > a - b
 scalarSub :: Scalar -> Scalar -> Scalar
 scalarSub a b =
-    withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb -> do
-        borrow <- ccryptonite_p256_sub pa pb d
-        when (borrow /= 0) $ void $ ccryptonite_p256_add d ccryptonite_SECP256r1_n d
-        --needReducing <- scalarNeedReducing d
-        --when needReducing $ do
-        --    ccryptonite_p256_mod ccryptonite_SECP256r1_n d d
+    withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb ->
+        ccryptonite_p256e_modsub ccryptonite_SECP256r1_n pa pb d
 
 -- | Perform multiplication between two scalars
 --
@@ -390,12 +377,12 @@ foreign import ccall "cryptonite_p256_is_zero"
     ccryptonite_p256_is_zero :: Ptr P256Scalar -> IO CInt
 foreign import ccall "cryptonite_p256_clear"
     ccryptonite_p256_clear :: Ptr P256Scalar -> IO ()
-foreign import ccall "cryptonite_p256_add"
-    ccryptonite_p256_add :: Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> IO CInt
+foreign import ccall "cryptonite_p256e_modadd"
+    ccryptonite_p256e_modadd :: Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> IO ()
 foreign import ccall "cryptonite_p256_add_d"
     ccryptonite_p256_add_d :: Ptr P256Scalar -> P256Digit -> Ptr P256Scalar -> IO CInt
-foreign import ccall "cryptonite_p256_sub"
-    ccryptonite_p256_sub :: Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> IO CInt
+foreign import ccall "cryptonite_p256e_modsub"
+    ccryptonite_p256e_modsub :: Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> IO ()
 foreign import ccall "cryptonite_p256_cmp"
     ccryptonite_p256_cmp :: Ptr P256Scalar -> Ptr P256Scalar -> IO CInt
 foreign import ccall "cryptonite_p256_mod"

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -39,6 +39,7 @@ module Crypto.PubKey.ECC.P256
     , scalarSub
     , scalarMul
     , scalarInv
+    , scalarInvSafe
     , scalarCmp
     , scalarFromBinary
     , scalarToBinary
@@ -290,6 +291,14 @@ scalarInv a =
     withNewScalarFreeze $ \b -> withScalar a $ \pa ->
         ccryptonite_p256_modinv_vartime ccryptonite_SECP256r1_n pa b
 
+-- | Give the inverse of the scalar using safe exponentiation
+--
+-- > 1 / a
+scalarInvSafe :: Scalar -> Scalar
+scalarInvSafe a =
+    withNewScalarFreeze $ \b -> withScalar a $ \pa ->
+        ccryptonite_p256e_scalar_invert pa b
+
 -- | Compare 2 Scalar
 scalarCmp :: Scalar -> Scalar -> Ordering
 scalarCmp a b = unsafeDoIO $
@@ -393,6 +402,8 @@ foreign import ccall "cryptonite_p256_mod"
     ccryptonite_p256_mod :: Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> IO ()
 foreign import ccall "cryptonite_p256_modmul"
     ccryptonite_p256_modmul :: Ptr P256Scalar -> Ptr P256Scalar -> P256Digit -> Ptr P256Scalar -> Ptr P256Scalar -> IO ()
+foreign import ccall "cryptonite_p256e_scalar_invert"
+    ccryptonite_p256e_scalar_invert :: Ptr P256Scalar -> Ptr P256Scalar -> IO ()
 --foreign import ccall "cryptonite_p256_modinv"
 --    ccryptonite_p256_modinv :: Ptr P256Scalar -> Ptr P256Scalar -> Ptr P256Scalar -> IO ()
 foreign import ccall "cryptonite_p256_modinv_vartime"

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -8,8 +8,8 @@
 -- P256 support
 --
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 module Crypto.PubKey.ECC.P256
     ( Scalar
@@ -22,7 +22,9 @@ module Crypto.PubKey.ECC.P256
     , pointDh
     , pointsMulVarTime
     , pointIsValid
+    , pointIsAtInfinity
     , toPoint
+    , pointX
     , pointToIntegers
     , pointFromIntegers
     , pointToBinary
@@ -31,6 +33,7 @@ module Crypto.PubKey.ECC.P256
     -- * Scalar arithmetic
     , scalarGenerate
     , scalarZero
+    , scalarN
     , scalarIsZero
     , scalarAdd
     , scalarSub
@@ -147,6 +150,19 @@ pointIsValid p = unsafeDoIO $ withPoint p $ \px py -> do
     r <- ccryptonite_p256_is_valid_point px py
     return (r /= 0)
 
+-- | Check if a 'Point' is the point at infinity
+pointIsAtInfinity :: Point -> Bool
+pointIsAtInfinity (Point b) = constAllZero b
+
+-- | Return the x coordinate as a 'Scalar' if the point is not at infinity
+pointX :: Point -> Maybe Scalar
+pointX p
+    | pointIsAtInfinity p = Nothing
+    | otherwise           = Just $
+        withNewScalarFreeze $ \d    ->
+        withPoint p         $ \px _ ->
+            ccryptonite_p256_mod ccryptonite_SECP256r1_n (castPtr px) (castPtr d)
+
 -- | Convert a point to (x,y) Integers
 pointToIntegers :: Point -> (Integer, Integer)
 pointToIntegers p = unsafeDoIO $ withPoint p $ \px py ->
@@ -216,6 +232,10 @@ scalarGenerate = unwrap . scalarFromBinary . witness <$> getRandomBytes 32
 -- | The scalar representing 0
 scalarZero :: Scalar
 scalarZero = withNewScalarFreeze $ \d -> ccryptonite_p256_init d
+
+-- | The scalar representing the curve order
+scalarN :: Scalar
+scalarN = Scalar "\x51\x25\x63\xFC\xC2\xCA\xB9\xF3\x84\x9E\x17\xA7\xAD\xFA\xE6\xBC\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF"
 
 -- | Check if the scalar is 0
 scalarIsZero :: Scalar -> Bool

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -34,6 +34,7 @@ module Crypto.PubKey.ECC.P256
     , scalarIsZero
     , scalarAdd
     , scalarSub
+    , scalarMul
     , scalarInv
     , scalarCmp
     , scalarFromBinary
@@ -250,6 +251,14 @@ scalarSub a b =
         --needReducing <- scalarNeedReducing d
         --when needReducing $ do
         --    ccryptonite_p256_mod ccryptonite_SECP256r1_n d d
+
+-- | Perform multiplication between two scalars
+--
+-- > a * b
+scalarMul :: Scalar -> Scalar -> Scalar
+scalarMul a b =
+    withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb ->
+         ccryptonite_p256_modmul ccryptonite_SECP256r1_n pa 0 pb d
 
 -- | Give the inverse of the scalar
 --

--- a/Crypto/PubKey/ECDSA.hs
+++ b/Crypto/PubKey/ECDSA.hs
@@ -1,0 +1,343 @@
+-- |
+-- Module      : Crypto.PubKey.ECDSA
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : unknown
+--
+-- Elliptic Curve Digital Signature Algorithm, with the parameterized
+-- curve implementations provided by module "Crypto.ECC".
+--
+-- Public/private key pairs can be generated using
+-- 'curveGenerateKeyPair' or decoded from binary.
+--
+-- /WARNING:/ Only curve P-256 has constant-time implementation.
+-- Signature operations with P-384 and P-521 may leak the private key.
+--
+-- Signature verification should be safe for all curves.
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Crypto.PubKey.ECDSA
+    ( EllipticCurveECDSA
+    -- * Public keys
+    , PublicKey
+    , encodePublic
+    , decodePublic
+    , toPublic
+    -- * Private keys
+    , PrivateKey
+    , encodePrivate
+    , decodePrivate
+    -- * Signatures
+    , Signature(..)
+    , signatureFromIntegers
+    , signatureToIntegers
+    -- * Scalars
+    -- $scalars
+    , scalarFromInteger
+    , scalarToInteger
+    -- * Generation and verification
+    , signWith
+    , sign
+    , verify
+    ) where
+
+import           Control.Applicative
+import           Control.Monad
+
+import           Crypto.ECC
+import qualified Crypto.ECC.Simple.Prim as Simple
+import qualified Crypto.ECC.Simple.Types as Simple
+import           Crypto.Error
+import           Crypto.Hash
+import           Crypto.Internal.ByteArray (ByteArray, ByteArrayAccess)
+import qualified Crypto.Internal.ByteArray as B
+import           Crypto.Internal.Imports
+import           Crypto.Number.Basic (numBits)
+import           Crypto.Number.ModArithmetic (inverse)
+import           Crypto.Number.Serialize
+import qualified Crypto.PubKey.ECC.P256 as P256
+import           Crypto.Random.Types
+
+import           Data.Bits (shiftR)
+import           Data.Data
+
+-- | Represent a ECDSA signature namely R and S.
+data Signature curve = Signature
+    { sign_r :: Scalar curve -- ^ ECDSA r
+    , sign_s :: Scalar curve -- ^ ECDSA s
+    }
+
+deriving instance Eq (Scalar curve) => Eq (Signature curve)
+deriving instance Show (Scalar curve) => Show (Signature curve)
+
+instance NFData (Scalar curve) => NFData (Signature curve) where
+    rnf (Signature r s) = rnf r `seq` rnf s `seq` ()
+
+-- | ECDSA Public Key.
+type PublicKey curve = Point curve
+
+-- | ECDSA Private Key.
+type PrivateKey curve = Scalar curve
+
+-- | Elliptic curves with ECDSA capabilities.
+class BaseEllipticCurveECDSA curve => EllipticCurveECDSA curve
+
+instance EllipticCurveECDSA Curve_P256R1
+instance EllipticCurveECDSA Curve_P384R1
+instance EllipticCurveECDSA Curve_P521R1
+
+class (EllipticCurveArith curve, Eq (Scalar curve)) => BaseEllipticCurveECDSA curve where
+
+    scFromInteger :: proxy curve -> Integer -> CryptoFailable (Scalar curve)
+    scToInteger :: proxy curve -> Scalar curve -> Integer
+
+    encodeScalar :: ByteArray bs => proxy curve -> Scalar curve -> bs
+    decodeScalar :: ByteArray bs => proxy curve -> bs -> CryptoFailable (Scalar curve)
+
+    scalarIsZero :: proxy curve -> Scalar curve -> Bool
+    scalarIsValid :: proxy curve -> Scalar curve -> Bool
+
+    scalarAdd :: proxy curve -> Scalar curve -> Scalar curve -> Scalar curve
+    scalarMul :: proxy curve -> Scalar curve -> Scalar curve -> Scalar curve
+    scalarInv :: proxy curve -> Scalar curve -> Maybe (Scalar curve)
+
+    curveOrderBits :: proxy curve -> Int
+
+    toPoint :: proxy curve -> Scalar curve -> Point curve
+    pointX :: proxy curve -> Point curve -> Maybe (Scalar curve)
+    pointsMulVarTime :: proxy curve -> Scalar curve -> Scalar curve -> Point curve -> Point curve
+
+instance BaseEllipticCurveECDSA Curve_P256R1 where
+
+    encodeScalar _ = P256.scalarToBinary
+    decodeScalar _ = P256.scalarFromBinary
+
+    scFromInteger _ = P256.scalarFromInteger
+    scToInteger _ = P256.scalarToInteger
+
+    scalarIsZero _ = P256.scalarIsZero
+    scalarIsValid _ s = not (P256.scalarIsZero s)
+                            && P256.scalarCmp s P256.scalarN == LT
+
+    scalarAdd _ = P256.scalarAdd
+    scalarMul _ = P256.scalarMul
+    scalarInv _ s = let inv = P256.scalarInvSafe s
+                     in if P256.scalarIsZero inv then Nothing else Just inv
+
+    curveOrderBits _ = 256
+
+    toPoint _ = P256.toPoint
+    pointX _  = P256.pointX
+    pointsMulVarTime _ = P256.pointsMulVarTime
+
+instance BaseEllipticCurveECDSA Curve_P384R1 where
+
+    encodeScalar _ = ecScalarToBinary
+    decodeScalar _ = ecScalarFromBinary
+
+    scFromInteger _ = ecScalarFromInteger
+    scToInteger _ = ecScalarToInteger
+
+    scalarIsZero _ (Simple.Scalar s) = s == 0
+    scalarIsValid _ = ecScalarIsValid (Proxy :: Proxy Simple.SEC_p384r1)
+
+    scalarAdd _ = ecScalarAdd (Proxy :: Proxy Simple.SEC_p384r1)
+    scalarMul _ = ecScalarMul (Proxy :: Proxy Simple.SEC_p384r1)
+    scalarInv _ = ecScalarInv (Proxy :: Proxy Simple.SEC_p384r1)
+
+    curveOrderBits _ = 384
+
+    toPoint _ = Simple.pointBaseMul
+    pointX _  = ecPointX (Proxy :: Proxy Simple.SEC_p384r1)
+    pointsMulVarTime _ = ecPointsMulVarTime (Proxy :: Proxy Simple.SEC_p384r1)
+
+instance BaseEllipticCurveECDSA Curve_P521R1 where
+
+    encodeScalar _ = ecScalarToBinary
+    decodeScalar _ = ecScalarFromBinary
+
+    scFromInteger _ = ecScalarFromInteger
+    scToInteger _ = ecScalarToInteger
+
+    scalarIsZero _ (Simple.Scalar s) = s == 0
+    scalarIsValid _ = ecScalarIsValid (Proxy :: Proxy Simple.SEC_p521r1)
+
+    scalarAdd _ = ecScalarAdd (Proxy :: Proxy Simple.SEC_p521r1)
+    scalarMul _ = ecScalarMul (Proxy :: Proxy Simple.SEC_p521r1)
+    scalarInv _ = ecScalarInv (Proxy :: Proxy Simple.SEC_p521r1)
+
+    curveOrderBits _ = 521
+
+    toPoint _ = Simple.pointBaseMul
+    pointX _  = ecPointX (Proxy :: Proxy Simple.SEC_p521r1)
+    pointsMulVarTime _ = ecPointsMulVarTime (Proxy :: Proxy Simple.SEC_p521r1)
+
+
+-- | Create a signature from integers (R, S).
+signatureFromIntegers :: EllipticCurveECDSA curve
+                      => proxy curve -> (Integer, Integer) -> CryptoFailable (Signature curve)
+signatureFromIntegers prx (r, s) =
+    liftA2 Signature (scalarFromInteger prx r) (scalarFromInteger prx s)
+
+-- | Get integers (R, S) from a signature.
+--
+-- The values can then be used to encode the signature to binary with
+-- ASN.1.
+signatureToIntegers :: EllipticCurveECDSA curve
+                    => proxy curve -> Signature curve -> (Integer, Integer)
+signatureToIntegers prx sig =
+    (scalarToInteger prx $ sign_r sig, scalarToInteger prx $ sign_s sig)
+
+-- | Encode a public key into binary form, i.e. the uncompressed encoding
+-- referenced from <https://tools.ietf.org/html/rfc5480 RFC 5480> section 2.2.
+encodePublic :: (EllipticCurve curve, ByteArray bs)
+             => proxy curve -> PublicKey curve -> bs
+encodePublic = encodePoint
+
+-- | Try to decode the binary form of a public key.
+decodePublic :: (EllipticCurve curve, ByteArray bs)
+             => proxy curve -> bs -> CryptoFailable (PublicKey curve)
+decodePublic = decodePoint
+
+-- | Encode a private key into binary form, i.e. the @privateKey@ field
+-- described in <https://tools.ietf.org/html/rfc5915 RFC 5915>.
+encodePrivate :: (EllipticCurveECDSA curve, ByteArray bs)
+              => proxy curve -> PrivateKey curve -> bs
+encodePrivate = encodeScalar
+
+-- | Try to decode the binary form of a private key.
+decodePrivate :: (EllipticCurveECDSA curve, ByteArray bs)
+              => proxy curve -> bs -> CryptoFailable (PrivateKey curve)
+decodePrivate = decodeScalar
+
+-- | Create a public key from a private key.
+toPublic :: EllipticCurveECDSA curve
+         => proxy curve -> PrivateKey curve -> PublicKey curve
+toPublic = toPoint
+
+-- $scalars
+--
+-- Random scalars are generated using 'curveGenerateScalar'.
+--
+-- Conversion to/from 'Integer' is also provided but this
+-- transformation to variable-size data type may leak information.
+
+-- | Create a scalar from an integer.
+scalarFromInteger :: EllipticCurveECDSA curve
+                  => proxy curve -> Integer -> CryptoFailable (Scalar curve)
+scalarFromInteger = scFromInteger
+
+-- | Transform a scalar to an integer.
+scalarToInteger :: EllipticCurveECDSA curve
+                => proxy curve -> Scalar curve -> Integer
+scalarToInteger = scToInteger
+
+
+-- | Sign message using the private key and an explicit k scalar.
+signWith :: (EllipticCurveECDSA curve, ByteArrayAccess msg, HashAlgorithm hash)
+         => proxy curve -> Scalar curve -> PrivateKey curve -> hash -> msg -> Maybe (Signature curve)
+signWith prx k d hashAlg msg = do
+    let z = tHash prx hashAlg msg
+        point = toPoint prx k
+    r <- pointX prx point
+    kInv <- scalarInv prx k
+    let s = scalarMul prx kInv (scalarAdd prx z (scalarMul prx r d))
+    when (scalarIsZero prx r || scalarIsZero prx s) Nothing
+    return $ Signature r s
+
+-- | Sign a message using hash and private key.
+sign :: (EllipticCurveECDSA curve, MonadRandom m, ByteArrayAccess msg, HashAlgorithm hash)
+     => proxy curve -> PrivateKey curve -> hash -> msg -> m (Signature curve)
+sign prx pk hashAlg msg = do
+    k <- curveGenerateScalar prx
+    case signWith prx k pk hashAlg msg of
+        Nothing  -> sign prx pk hashAlg msg
+        Just sig -> return sig
+
+-- | Verify a signature using hash and public key.
+verify :: (EllipticCurveECDSA curve, ByteArrayAccess msg, HashAlgorithm hash)
+       => proxy curve -> hash -> PublicKey curve -> Signature curve -> msg -> Bool
+verify prx hashAlg q (Signature r s) msg
+    | not (scalarIsValid prx r) = False
+    | not (scalarIsValid prx s) = False
+    | otherwise = maybe False (== r) $ do
+        w <- scalarInv prx s
+        let z  = tHash prx hashAlg msg
+            u1 = scalarMul prx z w
+            u2 = scalarMul prx r w
+            x  = pointsMulVarTime prx u1 u2 q
+        pointX prx x
+    -- Note: precondition q /= PointO is not tested because we assume
+    -- point decoding never decodes point at infinity.
+
+-- | Truncate and hash.
+tHash :: (EllipticCurveECDSA curve, ByteArrayAccess msg, HashAlgorithm hash)
+      => proxy curve -> hash -> msg -> Scalar curve
+tHash prx hashAlg m =
+    throwCryptoError $ scalarFromInteger prx (if d > 0 then shiftR e d else e)
+  where e = os2ip $ hashWith hashAlg m
+        d = hashDigestSize hashAlg * 8 - curveOrderBits prx
+
+
+ecScalarFromBinary :: forall curve bs . (Simple.Curve curve, ByteArrayAccess bs)
+                   => bs -> CryptoFailable (Simple.Scalar curve)
+ecScalarFromBinary ba
+    | B.length ba /= size = CryptoFailed CryptoError_SecretKeySizeInvalid
+    | otherwise           = CryptoPassed (Simple.Scalar $ os2ip ba)
+  where size = ecCurveOrderBytes (Proxy :: Proxy curve)
+
+ecScalarToBinary :: forall curve bs . (Simple.Curve curve, ByteArray bs)
+                 => Simple.Scalar curve -> bs
+ecScalarToBinary (Simple.Scalar s) = i2ospOf_ size s
+  where size = ecCurveOrderBytes (Proxy :: Proxy curve)
+
+ecScalarFromInteger :: forall curve . Simple.Curve curve
+                    => Integer -> CryptoFailable (Simple.Scalar curve)
+ecScalarFromInteger s
+    | numBits s > nb = CryptoFailed CryptoError_SecretKeySizeInvalid
+    | otherwise      = CryptoPassed (Simple.Scalar s)
+  where nb = 8 * ecCurveOrderBytes (Proxy :: Proxy curve)
+
+ecScalarToInteger :: Simple.Scalar curve -> Integer
+ecScalarToInteger (Simple.Scalar s) = s
+
+ecScalarIsValid :: Simple.Curve c => proxy c -> Simple.Scalar c -> Bool
+ecScalarIsValid prx (Simple.Scalar s) = s > 0 && s < n
+  where n = Simple.curveEccN $ Simple.curveParameters prx
+
+ecScalarAdd :: Simple.Curve c
+            => proxy c -> Simple.Scalar c -> Simple.Scalar c -> Simple.Scalar c
+ecScalarAdd prx (Simple.Scalar a) (Simple.Scalar b) =
+    Simple.Scalar ((a + b) `mod` n)
+  where n = Simple.curveEccN $ Simple.curveParameters prx
+
+ecScalarMul :: Simple.Curve c
+            => proxy c -> Simple.Scalar c -> Simple.Scalar c -> Simple.Scalar c
+ecScalarMul prx (Simple.Scalar a) (Simple.Scalar b) =
+    Simple.Scalar ((a * b) `mod` n)
+  where n = Simple.curveEccN $ Simple.curveParameters prx
+
+ecScalarInv :: Simple.Curve c
+            => proxy c -> Simple.Scalar c -> Maybe (Simple.Scalar c)
+ecScalarInv prx (Simple.Scalar s) = Simple.Scalar `fmap` inverse s n
+  where n = Simple.curveEccN $ Simple.curveParameters prx
+
+ecPointX :: Simple.Curve c
+         => proxy c -> Simple.Point c -> Maybe (Simple.Scalar c)
+ecPointX _   Simple.PointO      = Nothing
+ecPointX prx (Simple.Point x _) = Just (Simple.Scalar $ x `mod` n)
+  where n = Simple.curveEccN $ Simple.curveParameters prx
+
+ecPointsMulVarTime :: Simple.Curve c
+                   => proxy c -> Simple.Scalar c -> Simple.Scalar c
+                   -> Simple.Point c -> Simple.Point c
+ecPointsMulVarTime prx n1 n2 p = Simple.pointAddTwoMuls n1 g n2 p
+  where g = Simple.curveEccG $ Simple.curveParameters prx
+
+ecCurveOrderBytes :: Simple.Curve c => proxy c -> Int
+ecCurveOrderBytes prx = (numBits n + 7) `div` 8
+  where n = Simple.curveEccN $ Simple.curveParameters prx

--- a/cbits/p256/p256.c
+++ b/cbits/p256/p256.c
@@ -391,6 +391,22 @@ void cryptonite_p256_to_bin(const cryptonite_p256_int* src, uint8_t dst[P256_NBY
   "p256e" functions are not part of the original source
 */
 
+// c = a + b mod MOD
+void cryptonite_p256e_modadd(const cryptonite_p256_int* MOD, const cryptonite_p256_int* a, const cryptonite_p256_int* b, cryptonite_p256_int* c) {
+  int carry = cryptonite_p256_add(a, b, c);
+
+  // same as cryptonite_p256_mod, but with top = carry
+  addM(MOD, 0, P256_DIGITS(c), subM(MOD, carry, P256_DIGITS(c), -1));
+}
+
+// c = a - b mod MOD
+void cryptonite_p256e_modsub(const cryptonite_p256_int* MOD, const cryptonite_p256_int* a, const cryptonite_p256_int* b, cryptonite_p256_int* c) {
+  int borrow = cryptonite_p256_sub(a, b, c);
+
+  // use borrow as mask in order to make difference positive when necessary
+  addM(MOD, 0, P256_DIGITS(c), borrow);
+}
+
 // n' such as n * n' = -1 mod (2^32)
 #define MONTGOMERY_FACTOR 0xEE00BC4F
 

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -153,6 +153,7 @@ Library
                      Crypto.PubKey.ECC.ECDSA
                      Crypto.PubKey.ECC.P256
                      Crypto.PubKey.ECC.Types
+                     Crypto.PubKey.ECDSA
                      Crypto.PubKey.ECIES
                      Crypto.PubKey.Ed25519
                      Crypto.PubKey.Ed448
@@ -375,6 +376,7 @@ Test-Suite test-cryptonite
                      BCrypt
                      ECC
                      ECC.Edwards25519
+                     ECDSA
                      Hash
                      Imports
                      KAT_AES.KATCBC

--- a/tests/ECDSA.hs
+++ b/tests/ECDSA.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+module ECDSA (tests) where
+
+import Crypto.Number.Serialize
+
+import qualified Crypto.ECC as ECDSA
+import qualified Crypto.PubKey.ECC.ECDSA as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.ECDSA as ECDSA
+import Crypto.Hash.Algorithms
+import Crypto.Error
+import qualified Data.ByteString as B
+
+import Imports
+
+data Curve = forall curve. (ECDSA.EllipticCurveECDSA curve, Show (ECDSA.Scalar curve)) => Curve curve ECC.Curve ECC.CurveName
+
+instance Show Curve where
+    showsPrec d (Curve _ _ name) = showsPrec d name
+
+instance Arbitrary Curve where
+    arbitrary = elements
+        [ makeCurve ECDSA.Curve_P256R1 ECC.SEC_p256r1
+        , makeCurve ECDSA.Curve_P384R1 ECC.SEC_p384r1
+        , makeCurve ECDSA.Curve_P521R1 ECC.SEC_p521r1
+        ]
+      where
+        makeCurve c name = Curve c (ECC.getCurveByName name) name
+
+arbitraryScalar curve = choose (1, n - 1)
+  where n = ECC.ecc_n (ECC.common_curve curve)
+
+sigECCToECDSA :: ECDSA.EllipticCurveECDSA curve
+              => proxy curve -> ECC.Signature -> ECDSA.Signature curve
+sigECCToECDSA prx (ECC.Signature r s) =
+    ECDSA.Signature (throwCryptoError $ ECDSA.scalarFromInteger prx r)
+                    (throwCryptoError $ ECDSA.scalarFromInteger prx s)
+
+tests = localOption (QuickCheckTests 5) $ testGroup "ECDSA"
+    [ testProperty "SHA1"   $ propertyECDSA SHA1
+    , testProperty "SHA224" $ propertyECDSA SHA224
+    , testProperty "SHA256" $ propertyECDSA SHA256
+    , testProperty "SHA384" $ propertyECDSA SHA384
+    , testProperty "SHA512" $ propertyECDSA SHA512
+    ]
+  where
+    propertyECDSA hashAlg (Curve c curve _) (ArbitraryBS0_2901 msg) = do
+        d    <- arbitraryScalar curve
+        kECC <- arbitraryScalar curve
+        let privECC   = ECC.PrivateKey curve d
+            prx       = Just c -- using Maybe as Proxy
+            kECDSA    = throwCryptoError $ ECDSA.scalarFromInteger prx kECC
+            privECDSA = throwCryptoError $ ECDSA.scalarFromInteger prx d
+            pubECDSA  = ECDSA.toPublic prx privECDSA
+            Just sigECC   = ECC.signWith kECC privECC hashAlg msg
+            Just sigECDSA = ECDSA.signWith prx kECDSA privECDSA hashAlg msg
+            sigECDSA' = sigECCToECDSA prx sigECC
+            msg' = msg `B.append` B.singleton 42
+        return $ propertyHold [ eqTest "signature" sigECDSA sigECDSA'
+                              , eqTest "verification" True (ECDSA.verify prx hashAlg pubECDSA sigECDSA' msg)
+                              , eqTest "alteration"  False (ECDSA.verify prx hashAlg pubECDSA sigECDSA msg')
+                              ]

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -88,6 +88,10 @@ tests = testGroup "P256"
                 v = unP256 r
                 v' = P256.scalarSub (unP256Scalar r) nm1
              in ((v - (curveN - 1)) `mod` curveN) `propertyEq` p256ScalarToInteger v'
+        , testProperty "mul" $ \r1 r2 ->
+            let r = (unP256 r1 * unP256 r2) `mod` curveN
+                r' = P256.scalarMul (unP256Scalar r1) (unP256Scalar r2)
+             in r `propertyEq` p256ScalarToInteger r'
         , testProperty "inv" $ \r' ->
             let inv  = inverseCoprimes (unP256 r') curveN
                 inv' = P256.scalarInv (unP256Scalar r')

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -95,7 +95,21 @@ tests = testGroup "P256"
         , testProperty "inv" $ \r' ->
             let inv  = inverseCoprimes (unP256 r') curveN
                 inv' = P256.scalarInv (unP256Scalar r')
-             in if unP256 r' == 0 then True else inv `propertyEq` p256ScalarToInteger inv'
+             in unP256 r' /= 0 ==> inv `propertyEq` p256ScalarToInteger inv'
+        , testProperty "inv-safe" $ \r' ->
+            let inv  = P256.scalarInv (unP256Scalar r')
+                inv' = P256.scalarInvSafe (unP256Scalar r')
+             in unP256 r' /= 0 ==> inv `propertyEq` inv'
+        , testProperty "inv-safe-mul" $ \r' ->
+            let inv = P256.scalarInvSafe (unP256Scalar r')
+                res = P256.scalarMul (unP256Scalar r') inv
+             in unP256 r' /= 0 ==> 1 `propertyEq` p256ScalarToInteger res
+        , testProperty "inv-safe-zero" $
+            let inv0 = P256.scalarInvSafe P256.scalarZero
+                invN = P256.scalarInvSafe P256.scalarN
+             in propertyHold [ eqTest "scalarZero" P256.scalarZero inv0
+                             , eqTest "scalarN"    P256.scalarZero invN
+                             ]
         ]
     , testGroup "point"
         [ testProperty "marshalling" $ \rx ry ->

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -118,6 +118,12 @@ tests = testGroup "P256"
         , testProperty "lift-to-curve" $ propertyLiftToCurve
         , testProperty "point-add" $ propertyPointAdd
         , testProperty "point-negate" $ propertyPointNegate
+        , testProperty "infinity" $
+            let gN = P256.toPoint P256.scalarN
+                g1 = P256.pointBase
+             in propertyHold [ eqTest "zero" True  (P256.pointIsAtInfinity gN)
+                             , eqTest "base" False (P256.pointIsAtInfinity g1)
+                             ]
         ]
     ]
   where

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -132,6 +132,7 @@ tests = testGroup "P256"
         , testProperty "lift-to-curve" $ propertyLiftToCurve
         , testProperty "point-add" $ propertyPointAdd
         , testProperty "point-negate" $ propertyPointNegate
+        , testProperty "point-mul" $ propertyPointMul
         , testProperty "infinity" $
             let gN = P256.toPoint P256.scalarN
                 g1 = P256.pointBase
@@ -166,6 +167,15 @@ tests = testGroup "P256"
             pe = ECC.pointMul curve (unP256 r) curveGen
             pR = P256.pointNegate p
          in ECC.pointNegate curve pe `propertyEq` (pointP256ToECC pR)
+
+    propertyPointMul s r =
+        let p     = P256.toPoint (unP256Scalar r)
+            pe    = ECC.pointMul curve (unP256 r) curveGen
+            pR    = P256.toPoint (P256.scalarMul (unP256Scalar s) (unP256Scalar r))
+            peR   = ECC.pointMul curve (unP256 s) pe
+         in propertyHold [ eqTest "p256" pR (P256.pointMul (unP256Scalar s) p)
+                         , eqTest "ecc" peR (pointP256ToECC pR)
+                         ]
 
     i2ospScalar :: Integer -> Bytes
     i2ospScalar i =

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -8,6 +8,7 @@ import qualified Number.F2m
 import qualified BCrypt
 import qualified ECC
 import qualified ECC.Edwards25519
+import qualified ECDSA
 import qualified Hash
 import qualified Poly1305
 import qualified Salsa
@@ -85,6 +86,7 @@ tests = testGroup "cryptonite"
     , KAT_AFIS.tests
     , ECC.tests
     , ECC.Edwards25519.tests
+    , ECDSA.tests
     ]
 
 main = defaultMain tests


### PR DESCRIPTION
Goal here is to get faster ECDSA implementation for P-256:
- removing some side-channels in primitive operations and adding scalar inversion with Fermat's little theorem
- implementing a clone of existing ECDSA API but based on Crypto.ECC

For now the type-class internals are not exposed, waiting for some extension of class hierarchy as explained in #225.