### PR TITLE
Support building against system argon2.

### DIFF
--- a/Crypto/KDF/Argon2.hs
+++ b/Crypto/KDF/Argon2.hs
@@ -147,7 +147,7 @@ cOfVariant Argon2id = 2
 csizeOfInt :: Int -> CSize
 csizeOfInt = fromIntegral
 
-foreign import ccall unsafe "cryptonite_argon2_hash"
+foreign import ccall unsafe "cryptonite_argon2_hash_haskell"
     argon2_hash :: Word32 -> Word32 -> Word32
                 -> Ptr Pass -> CSize
                 -> Ptr Salt -> CSize

--- a/cbits/cryptonite_argon2.c
+++ b/cbits/cryptonite_argon2.c
@@ -8,8 +8,14 @@ int cryptonite_argon2_hash_haskell(const uint32_t t_cost,
                                    const size_t hashlen, argon2_type type,
                                    const uint32_t version)
 {
+#ifdef USE_SYSTEM_LIBRARY
+	return argon2_hash(t_cost, m_cost, parallelism, pwd, pwdlen,
+	                   salt, saltlen, hash, hashlen, NULL, 0, type,
+		           version);
+#else
 	return cryptonite_argon2_hash(t_cost, m_cost, parallelism, pwd, pwdlen,
 	                              salt, saltlen, hash, hashlen, type,
 	                              version);
+#endif
 }
 

--- a/cbits/cryptonite_argon2.c
+++ b/cbits/cryptonite_argon2.c
@@ -1,0 +1,15 @@
+#include "cryptonite_argon2.h"
+
+int cryptonite_argon2_hash_haskell(const uint32_t t_cost,
+                                   const uint32_t m_cost,
+                                   const uint32_t parallelism, const void *pwd,
+                                   const size_t pwdlen, const void *salt,
+                                   const size_t saltlen, void *hash,
+                                   const size_t hashlen, argon2_type type,
+                                   const uint32_t version)
+{
+	return cryptonite_argon2_hash(t_cost, m_cost, parallelism, pwd, pwdlen,
+	                              salt, saltlen, hash, hashlen, type,
+	                              version);
+}
+

--- a/cbits/cryptonite_argon2.h
+++ b/cbits/cryptonite_argon2.h
@@ -1,0 +1,13 @@
+#ifndef CRYPTOHASH_ARGON2_H
+#define CRYPTOHASH_ARGON2_H
+
+#include "argon2.h"
+
+int cryptonite_argon2_hash_haskell(const uint32_t t_cost, const uint32_t m_cost,
+                                   const uint32_t parallelism, const void *pwd,
+                                   const size_t pwdlen, const void *salt,
+                                   const size_t saltlen, void *hash,
+                                   const size_t hashlen, argon2_type type,
+                                   const uint32_t version);
+
+#endif

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -247,6 +247,7 @@ Library
                    , cbits/cryptonite_cpu.c
                    , cbits/p256/p256.c
                    , cbits/p256/p256_ec.c
+                   , cbits/cryptonite_argon2.c
                    , cbits/cryptonite_blake2s.c
                    , cbits/cryptonite_blake2sp.c
                    , cbits/cryptonite_blake2b.c

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -62,6 +62,11 @@ source-repository head
   type: git
   location: https://github.com/haskell-crypto/cryptonite
 
+Flag use-system-library
+  Description: Use system @libargon2@ (via @pkg-config(1)@) and @blake2@ libraries instead of embedded copies
+  Default: False
+  manual: True
+
 Flag support_aesni
   Description:       allow compilation with AESNI on system and architecture that supports it
   Default:           True
@@ -78,7 +83,7 @@ Flag support_pclmuldq
   Manual:            True
 
 Flag support_sse
-  Description:       Use SSE optimized version of (BLAKE2, ARGON2)
+  Description:       Use SSE optimized version of (BLAKE2, ARGON2) (does nothing when using system libraries)
   Default:           False
   Manual:            True
 
@@ -344,11 +349,15 @@ Library
                   , cbits/blake2/ref/blake2bp-ref.c
     include-dirs: cbits/blake2/ref
 
-  if arch(x86_64) || flag(support_sse)
-    CPP-options:    -DSUPPORT_SSE
+  if flag(use-system-library)
+    CC-options:        -DUSE_SYSTEM_LIBRARY
+    PkgConfig-Depends: libargon2
+  else
+    if arch(x86_64) || flag(support_sse)
+      CPP-options:    -DSUPPORT_SSE
 
-  C-sources:      cbits/argon2/argon2.c
-  include-dirs:   cbits/argon2
+    C-sources:      cbits/argon2/argon2.c
+    include-dirs:   cbits/argon2
 
   if os(windows)
     cpp-options:    -DWINDOWS


### PR DESCRIPTION
This echos the option that exists in the `argon2` package to not use the internal copy and build against a system version.

In a way, this is an alternate way to "fix" #109 because there wouldn't be any internal copy of the symbols that could conflict.