### PR TITLE
Faster AES GCM with PCLMULQDQ

### DIFF
--- a/Crypto/Cipher/Types/Base.hs
+++ b/Crypto/Cipher/Types/Base.hs
@@ -22,6 +22,7 @@ module Crypto.Cipher.Types.Base
 import           Data.Word
 import           Crypto.Internal.ByteArray (Bytes, ByteArrayAccess, ByteArray)
 import qualified Crypto.Internal.ByteArray as B
+import           Crypto.Internal.DeepSeq
 import           Crypto.Error
 
 -- | Different specifier for key size in bytes
@@ -36,7 +37,7 @@ type DataUnitOffset = Word32
 
 -- | Authentication Tag for AE cipher mode
 newtype AuthTag = AuthTag { unAuthTag :: Bytes }
-    deriving (Show, ByteArrayAccess)
+    deriving (Show, ByteArrayAccess, NFData)
 
 instance Eq AuthTag where
     (AuthTag a) == (AuthTag b) = B.constEq a b

--- a/cbits/aes/gf.c
+++ b/cbits/aes/gf.c
@@ -39,7 +39,7 @@
  * to speed up the multiplication.
  * TODO: optimise with tables
  */
-void cryptonite_gf_mul(block128 *a, block128 *b)
+void cryptonite_aes_generic_gf_mul(block128 *a, block128 *b)
 {
 	uint64_t a0, a1, v0, v1;
 	int i, j;
@@ -62,7 +62,7 @@ void cryptonite_gf_mul(block128 *a, block128 *b)
 }
 
 /* inplace GFMUL for xts mode */
-void cryptonite_gf_mulx(block128 *a)
+void cryptonite_aes_generic_gf_mulx(block128 *a)
 {
 	const uint64_t gf_mask = cpu_to_le64(0x8000000000000000ULL);
 	uint64_t r = ((a->q[1] & gf_mask) ? cpu_to_le64(0x87) : 0);

--- a/cbits/aes/gf.h
+++ b/cbits/aes/gf.h
@@ -32,7 +32,7 @@
 
 #include "aes/block128.h"
 
-void cryptonite_gf_mul(block128 *a, block128 *b);
-void cryptonite_gf_mulx(block128 *a);
+void cryptonite_aes_generic_gf_mul(block128 *a, block128 *b);
+void cryptonite_aes_generic_gf_mulx(block128 *a);
 
 #endif

--- a/cbits/aes/x86ni.h
+++ b/cbits/aes/x86ni.h
@@ -72,7 +72,10 @@ void cryptonite_aesni_encrypt_xts256(aes_block *out, aes_key *key1, aes_key *key
 void cryptonite_aesni_gcm_encrypt128(uint8_t *out, aes_gcm *gcm, aes_key *key, uint8_t *in, uint32_t length);
 void cryptonite_aesni_gcm_encrypt256(uint8_t *out, aes_gcm *gcm, aes_key *key, uint8_t *in, uint32_t length);
 
-void gf_mul_x86ni(block128 *res, block128 *a_, block128 *b_);
+#ifdef WITH_PCLMUL
+void cryptonite_aesni_init_pclmul();
+void cryptonite_aesni_gf_mul(block128 *a, block128 *b);
+#endif
 
 #endif
 


### PR DESCRIPTION
Complements the AESNI implementation with CLMUL intrinsics when supported by the CPU.

Before:
```
AE/ChaChaPoly1305                        mean 7.682 μs  ( +- 168.9 ns  )
AE/AES-GCM                               mean 14.32 μs  ( +- 66.21 ns  )
AE/AES-CCM                               mean 21.58 μs  ( +- 96.51 ns  )
```

After (support_pclmuldq disabled):
```
AE/ChaChaPoly1305                        mean 7.728 μs  ( +- 199.7 ns  )
AE/AES-GCM                               mean 14.52 μs  ( +- 94.97 ns  )
AE/AES-CCM                               mean 21.70 μs  ( +- 199.7 ns  )
```

After (support_pclmuldq enabled):
```
AE/ChaChaPoly1305                        mean 7.698 μs  ( +- 170.2 ns  )
AE/AES-GCM                               mean 3.037 μs  ( +- 52.41 ns  )
AE/AES-CCM                               mean 21.65 μs  ( +- 151.6 ns  )
```

For now flag `support_pclmuldq` must still be enabled explicitely.