### PR TITLE
Num instances for ECC scalars

### DIFF
--- a/Crypto/ECC/Edwards25519.hs
+++ b/Crypto/ECC/Edwards25519.hs
@@ -64,6 +64,7 @@ module Crypto.ECC.Edwards25519
     -- * Arithmetic functions
     , toPoint
     , scalarAdd
+    , scalarSub
     , scalarMul
     , pointNegate
     , pointAdd
@@ -164,6 +165,14 @@ scalarAdd (Scalar a) (Scalar b) =
         withByteArray a $ \pa ->
         withByteArray b $ \pb ->
              ed25519_scalar_add out pa pb
+
+-- | Substract two scalars.
+scalarSub :: Scalar -> Scalar -> Scalar
+scalarSub (Scalar a) (Scalar b) =
+    Scalar $ B.allocAndFreeze scalarArraySize $ \out ->
+        withByteArray a $ \pa ->
+        withByteArray b $ \pb ->
+             ed25519_scalar_sub out pa pb
 
 -- | Multiply two scalars.
 scalarMul :: Scalar -> Scalar -> Scalar
@@ -301,6 +310,12 @@ foreign import ccall "cryptonite_ed25519_scalar_decode_long"
 
 foreign import ccall "cryptonite_ed25519_scalar_add"
     ed25519_scalar_add :: Ptr Scalar -- sum
+                       -> Ptr Scalar -- a
+                       -> Ptr Scalar -- b
+                       -> IO ()
+
+foreign import ccall "cryptonite_ed25519_scalar_sub"
+    ed25519_scalar_sub :: Ptr Scalar -- diff
                        -> Ptr Scalar -- a
                        -> Ptr Scalar -- b
                        -> IO ()

--- a/Crypto/ECC/Edwards25519.hs
+++ b/Crypto/ECC/Edwards25519.hs
@@ -83,6 +83,7 @@ import           Crypto.Internal.ByteArray (Bytes, ScrubbedBytes, withByteArray)
 import qualified Crypto.Internal.ByteArray as B
 import           Crypto.Internal.Compat
 import           Crypto.Internal.Imports
+import           Crypto.Number.Serialize.LE (i2osp)
 import           Crypto.Random
 
 
@@ -99,6 +100,17 @@ instance Eq Scalar where
         withByteArray s2 $ \ps2 ->
             fmap (/= 0) (ed25519_scalar_eq ps1 ps2)
     {-# NOINLINE (==) #-}
+
+instance Num Scalar where
+    (+) = scalarAdd
+    (-) = scalarSub
+    (*) = scalarMul
+
+    abs = error "Edwards25519.Scalar: abs not implemented"
+    signum = error "Edwards25519.Scalar: signum not implemented"
+
+    fromInteger i = throwCryptoError (scalarDecodeLong bs)
+      where bs = i2osp i :: Bytes
 
 pointArraySize :: Int
 pointArraySize = 160 -- maximum [4 * 10 * 4 {- 32 bits -}, 4 * 5 * 8 {- 64 bits -}]

--- a/Crypto/ECC/Edwards25519.hs
+++ b/Crypto/ECC/Edwards25519.hs
@@ -110,7 +110,8 @@ instance Num Scalar where
     signum = error "Edwards25519.Scalar: signum not implemented"
 
     fromInteger i = throwCryptoError (scalarDecodeLong bs)
-      where bs = i2osp i :: Bytes
+      where bs = i2osp (i `mod` order) :: Bytes
+            order = 2^(252::Int) + 27742317777372353535851937790883648493
 
 pointArraySize :: Int
 pointArraySize = 160 -- maximum [4 * 10 * 4 {- 32 bits -}, 4 * 5 * 8 {- 64 bits -}]

--- a/Crypto/ECC/Simple/Types.hs
+++ b/Crypto/ECC/Simple/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- |
 -- Module      : Crypto.ECC.Simple.Types
 -- License     : BSD-style
@@ -100,6 +101,26 @@ data CurveType =
 -- | ECC Private Number
 newtype Scalar curve = Scalar Integer
     deriving (Show,Read,Eq,Data,NFData)
+
+instance Curve curve => Num (Scalar curve) where
+    (+) = scalarOp (+)
+    (-) = scalarOp (-)
+    (*) = scalarOp (*)
+
+    negate (Scalar a) = Scalar (n - a)
+      where n = curveEccN $ curveParameters (Proxy :: Proxy curve)
+
+    abs = error "Simple.Scalar: abs not implemented"
+    signum = error "Simple.Scalar: signum not implemented"
+
+    fromInteger i = Scalar (i `mod` n)
+      where n = curveEccN $ curveParameters (Proxy :: Proxy curve)
+
+scalarOp :: forall curve . Curve curve
+         => (Integer -> Integer -> Integer)
+         -> Scalar curve -> Scalar curve -> Scalar curve
+scalarOp op (Scalar a) (Scalar b) = Scalar (op a b `mod` n)
+  where n = curveEccN $ curveParameters (Proxy :: Proxy curve)
 
 -- | Define a point on a curve.
 data Point curve =

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -61,6 +61,18 @@ import qualified Crypto.Number.Serialize as S (os2ip, i2ospOf)
 newtype Scalar = Scalar ScrubbedBytes
     deriving (Show,Eq,ByteArrayAccess,NFData)
 
+instance Num Scalar where
+    (+) = scalarAdd
+    (-) = scalarSub
+    (*) = scalarMul
+
+    negate = scalarSub scalarN
+
+    abs = error "P256.Scalar: abs not implemented"
+    signum = error "P256.Scalar: signum not implemented"
+
+    fromInteger i = throwCryptoError $ scalarFromInteger (i `mod` order)
+
 -- | A P256 point
 newtype Point = Point Bytes
     deriving (Show,Eq,NFData)
@@ -76,6 +88,9 @@ type P256Digit  = Word32
 data P256Scalar
 data P256Y
 data P256X
+
+order :: Integer
+order = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
 
 ------------------------------------------------------------------------
 -- Point methods
@@ -215,6 +230,10 @@ scalarGenerate = unwrap . scalarFromBinary . witness <$> getRandomBytes 32
 -- | The scalar representing 0
 scalarZero :: Scalar
 scalarZero = withNewScalarFreeze $ \d -> ccryptonite_p256_init d
+
+-- | The scalar representing the curve order
+scalarN :: Scalar
+scalarN = throwCryptoError (scalarFromInteger order)
 
 -- | Check if the scalar is 0
 scalarIsZero :: Scalar -> Bool

--- a/Crypto/PubKey/ECC/P256.hs
+++ b/Crypto/PubKey/ECC/P256.hs
@@ -34,6 +34,7 @@ module Crypto.PubKey.ECC.P256
     , scalarIsZero
     , scalarAdd
     , scalarSub
+    , scalarMul
     , scalarInv
     , scalarCmp
     , scalarFromBinary
@@ -236,6 +237,14 @@ scalarSub :: Scalar -> Scalar -> Scalar
 scalarSub a b =
     withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb ->
         ccryptonite_p256e_modsub ccryptonite_SECP256r1_n pa pb d
+
+-- | Perform multiplication between two scalars
+--
+-- > a * b
+scalarMul :: Scalar -> Scalar -> Scalar
+scalarMul a b =
+    withNewScalarFreeze $ \d -> withScalar a $ \pa -> withScalar b $ \pb ->
+         ccryptonite_p256_modmul ccryptonite_SECP256r1_n pa 0 pb d
 
 -- | Give the inverse of the scalar
 --

--- a/tests/ECC/Edwards25519.hs
+++ b/tests/ECC/Edwards25519.hs
@@ -52,6 +52,12 @@ tests = testGroup "ECC.Edwards25519"
             scalarAdd sa (scalarAdd sb sc) === scalarAdd (scalarAdd sa sb) sc
         , testProperty "addition commutative" $ \sa sb ->
             scalarAdd sa sb === scalarAdd sb sa
+        , testProperty "substraction with zero" $ \s ->
+            s `propertyEq` scalarSub s s0
+        , testProperty "substraction non-associative" $ \sa sb sc ->
+            scalarSub sa (scalarSub sb sc) === scalarSub (scalarAdd sa sc) sb
+        , testProperty "substraction anticommutative" $ \sa sb ->
+            s0 `propertyEq` (scalarSub sa sb `scalarAdd` scalarSub sb sa)
         , testProperty "multiplication with zero" $ \s ->
             propertyHold [ eqTest "zero left"  s0 (scalarMul s0 s)
                          , eqTest "zero right" s0 (scalarMul s s0)
@@ -65,10 +71,14 @@ tests = testGroup "ECC.Edwards25519"
         , testProperty "multiplication commutative" $ \sa sb ->
             scalarMul sa sb === scalarMul sb sa
         , testProperty "multiplication distributive" $ \sa sb sc ->
-            propertyHold [ eqTest "distributive left"  ((sa `scalarMul` sb) `scalarAdd` (sa `scalarMul` sc))
-                                                       (sa `scalarMul` (sb `scalarAdd` sc))
-                         , eqTest "distributive right" ((sb `scalarMul` sa) `scalarAdd` (sc `scalarMul` sa))
-                                                       ((sb `scalarAdd` sc) `scalarMul` sa)
+            propertyHold [ eqTest "distributive add left"  ((sa `scalarMul` sb) `scalarAdd` (sa `scalarMul` sc))
+                                                           (sa `scalarMul` (sb `scalarAdd` sc))
+                         , eqTest "distributive add right" ((sb `scalarMul` sa) `scalarAdd` (sc `scalarMul` sa))
+                                                           ((sb `scalarAdd` sc) `scalarMul` sa)
+                         , eqTest "distributive sub left"  ((sa `scalarMul` sb) `scalarSub` (sa `scalarMul` sc))
+                                                           (sa `scalarMul` (sb `scalarSub` sc))
+                         , eqTest "distributive sub right" ((sb `scalarMul` sa) `scalarSub` (sc `scalarMul` sa))
+                                                           ((sb `scalarSub` sc) `scalarMul` sa)
                          ]
         ]
     , testGroup "point arithmetic"

--- a/tests/KAT_PubKey/P256.hs
+++ b/tests/KAT_PubKey/P256.hs
@@ -92,6 +92,10 @@ tests = testGroup "P256"
             let v = unP256 r `mod` curveN
                 v' = P256.scalarSub (unP256Scalar r) P256.scalarZero
              in v `propertyEq` p256ScalarToInteger v'
+        , testProperty "mul" $ \r1 r2 ->
+            let r = (unP256 r1 * unP256 r2) `mod` curveN
+                r' = P256.scalarMul (unP256Scalar r1) (unP256Scalar r2)
+             in r `propertyEq` p256ScalarToInteger r'
         , testProperty "inv" $ \r' ->
             let inv  = inverseCoprimes (unP256 r') curveN
                 inv' = P256.scalarInv (unP256Scalar r')


### PR DESCRIPTION
Adds missing scalar primitives as well as `Num` instances. Except `abs` and `signum` are not implemented because there could be multiple conventions for them.