### PR TITLE
Add a build option to use blake2 prehashing for ed25519 signatures

### DIFF
--- a/cbits/ed25519/ed25519-hash.h
+++ b/cbits/ed25519/ed25519-hash.h
@@ -1,3 +1,5 @@
+#ifndef ED25519_USING_BLAKE2
+
 #include <cryptonite_sha512.h>
 typedef struct sha512_ctx ed25519_hash_context;
 
@@ -24,3 +26,34 @@ ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
 	cryptonite_sha512_finalize(&ctx, hash);
 	memset(&ctx, 0, sizeof(ctx));
 }
+
+#else /* ED25519_USING_BLAKE2 */
+
+#include <cryptonite_blake2b.h>
+typedef blake2b_ctx ed25519_hash_context;
+
+static void
+ed25519_hash_init(ed25519_hash_context *ctx) {
+	cryptonite_blake2b_init(ctx, 512);
+}
+
+static void
+ed25519_hash_update(ed25519_hash_context *ctx, const uint8_t *in, size_t inlen) {
+	cryptonite_blake2b_update(ctx, in, inlen);
+}
+
+static void
+ed25519_hash_final(ed25519_hash_context *ctx, uint8_t *hash) {
+	cryptonite_blake2b_finalize(ctx, 512, hash);
+}
+
+static void
+ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
+	ed25519_hash_context ctx;
+	cryptonite_blake2b_init(&ctx, 512);
+	cryptonite_blake2b_update(&ctx, in, inlen);
+	cryptonite_blake2b_finalize(&ctx, 512, hash);
+	memset(&ctx, 0, sizeof(ctx));
+}
+
+#endif /* ED25519_USING_BLAKE2 */

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -102,6 +102,11 @@ Flag check_alignment
   Default:           False
   Manual:            True
 
+Flag ed25519_using_blake2
+  Description:       Use BLAKE2 as the prehash for ED25519 signatures
+  Default:           False
+  Manual:            True
+
 Library
   Exposed-modules:   Crypto.Cipher.AES
                      Crypto.Cipher.AESGCMSIV
@@ -377,6 +382,10 @@ Library
   if flag(check_alignment)
     cc-options:     -DWITH_ASSERT_ALIGNMENT
 
+  if flag(ed25519_using_blake2)
+    CPP-options:     -DED25519_USING_BLAKE2
+    cc-options:      -DED25519_USING_BLAKE2
+
 Test-Suite test-cryptonite
   type:              exitcode-stdio-1.0
   hs-source-dirs:    tests
@@ -445,6 +454,10 @@ Test-Suite test-cryptonite
                    , cryptonite
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures -rtsopts
   default-language:  Haskell2010
+
+  if flag(ed25519_using_blake2)
+    CPP-options:     -DED25519_USING_BLAKE2
+    cc-options:      -DED25519_USING_BLAKE2
 
 Benchmark bench-cryptonite
   type:              exitcode-stdio-1.0


### PR DESCRIPTION
The default prehashing algorithm is `sha512` but the `ed25519` specification allows alternative hash algorithms to be used, and some crypto applications are now using `blake2`.

Ideally this would be a runtime choice, but that:

* has a performance impact;
* would involve adding to the external API;
* would take a lot more work to implement.

I think it's rare that a library client would need to use multiple types of hashing with `ed25519`.

Unfortunately, I couldn't find any readily available test vectors for `ed25519` with `blake2` so I've disabled those tests when the flag is on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/haskell-crypto/cryptonite/298)
<!-- Reviewable:end -->
