### PR TITLE
Fix typos

### DIFF
--- a/Crypto/ConstructHash/MiyaguchiPreneel.hs
+++ b/Crypto/ConstructHash/MiyaguchiPreneel.hs
@@ -44,7 +44,7 @@ compute' g = MP . foldl' (step $ g) (B.replicate bsz 0) . chunks . pad (ZERO bsz
       where
         (hd, tl) = B.splitAt bsz msg
 
--- | Compute Miyaguchi-Preneel one way compress using the infered block cipher.
+-- | Compute Miyaguchi-Preneel one way compress using the inferred block cipher.
 --   Only safe when KEY-SIZE equals to BLOCK-SIZE.
 --
 --   Simple usage /mp' msg :: MiyaguchiPreneel AES128/

--- a/Crypto/Data/Padding.hs
+++ b/Crypto/Data/Padding.hs
@@ -6,7 +6,7 @@
 -- Portability : unknown
 --
 -- Various cryptographic padding commonly used for block ciphers
--- or assymetric systems.
+-- or asymmetric systems.
 --
 module Crypto.Data.Padding
     ( Format(..)

--- a/Crypto/Number/ModArithmetic.hs
+++ b/Crypto/Number/ModArithmetic.hs
@@ -56,7 +56,7 @@ expSafe b e m
 -- hiding parameters.
 --
 -- Use this function when all the parameters are public,
--- otherwise 'expSafe' should be prefered.
+-- otherwise 'expSafe' should be preferred.
 expFast :: Integer -- ^ base
         -> Integer -- ^ exponent
         -> Integer -- ^ modulo

--- a/Crypto/Number/Prime.hs
+++ b/Crypto/Number/Prime.hs
@@ -127,7 +127,7 @@ primalityTestMillerRabin tries !n =
     factorise :: Integer -> Integer -> (Integer, Integer)
     factorise !si !vi
         | vi `testBit` 0 = (si, vi)
-        | otherwise     = factorise (si+1) (vi `shiftR` 1) -- probably faster to not shift v continously, but just once.
+        | otherwise     = factorise (si+1) (vi `shiftR` 1) -- probably faster to not shift v continuously, but just once.
     expmod = expSafe
 
     -- when iteration reach zero, we have a probable prime

--- a/Crypto/System/CPU.hs
+++ b/Crypto/System/CPU.hs
@@ -31,7 +31,7 @@ import Crypto.Random.Entropy.RDRand
 import Crypto.Random.Entropy.Source
 #endif
 
--- | CPU options impacting cryptography implementation and libary performance.
+-- | CPU options impacting cryptography implementation and library performance.
 data ProcessorOption
     = AESNI   -- ^ Support for AES instructions, with flag @support_aesni@
     | PCLMUL  -- ^ Support for CLMUL instructions, with flag @support_pclmuldq@

--- a/cbits/cryptonite_rdrand.c
+++ b/cbits/cryptonite_rdrand.c
@@ -91,7 +91,7 @@ static inline int cryptonite_rdrand_step(RDRAND_T *buffer)
 }
 #endif
 
-/* Returns the number of bytes succesfully generated */
+/* Returns the number of bytes successfully generated */
 int cryptonite_get_rand_bytes(uint8_t *buffer, size_t len)
 {
 	RDRAND_T tmp;


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.