### PR TITLE
Better P256.pointMul performance

### DIFF
--- a/cbits/p256/p256_ec.c
+++ b/cbits/p256/p256_ec.c
@@ -1311,3 +1311,20 @@ void cryptonite_p256e_point_negate(
     memcpy(out_x, in_x, P256_NBYTES);
     cryptonite_p256_sub(&cryptonite_SECP256r1_p, in_y, out_y);
 }
+
+/* this function is not part of the original source
+   cryptonite_p256e_point_mul sets {out_x,out_y} = n*{in_x,in_y}, where
+   n is < the order of the group.
+ */
+void cryptonite_p256e_point_mul(const cryptonite_p256_int* n,
+    const cryptonite_p256_int* in_x, const cryptonite_p256_int* in_y,
+    cryptonite_p256_int* out_x, cryptonite_p256_int* out_y) {
+  felem x, y, z, px, py;
+
+  to_montgomery(px, in_x);
+  to_montgomery(py, in_y);
+  scalar_mult(x, y, z, px, py, n);
+  point_to_affine(px, py, x, y, z);
+  from_montgomery(out_x, px);
+  from_montgomery(out_y, py);
+}


### PR DESCRIPTION
Existing implementation does unnecessary work to multiply the basepoint with a scalar which is always zero. Using a specialized function skipping this saves 20-25% of the total time.

Before:
```
P256/pointAddTwoMuls-P256                mean 915.2 μs  ( +- 2.139 μs  )
P256/pointAdd-P256                       mean 28.51 μs  ( +- 92.76 ns  )
P256/pointMul-P256                       mean 443.5 μs  ( +- 1.059 μs  )
```

After:
```
P256/pointAddTwoMuls-P256                mean 719.6 μs  ( +- 1.809 μs  )
P256/pointAdd-P256                       mean 28.47 μs  ( +- 82.05 ns  )
P256/pointMul-P256                       mean 345.1 μs  ( +- 670.0 ns  )
```
