### PR TITLE
instance (MonadRandom m, MonadTrans t, Monad (t m)) => MonadRandom (t m)

### DIFF
--- a/Crypto/Random/Types.hs
+++ b/Crypto/Random/Types.hs
@@ -5,6 +5,10 @@
 -- Stability   : experimental
 -- Portability : Good
 --
+
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Crypto.Random.Types
     (
       MonadRandom(..)
@@ -13,11 +17,12 @@ module Crypto.Random.Types
     , withDRG
     ) where
 
+import Control.Monad.Trans.Class
 import Crypto.Random.Entropy
 import Crypto.Internal.ByteArray
 
 -- | A monad constraint that allows to generate random bytes
-class (Functor m, Monad m) => MonadRandom m where
+class (Monad m) => MonadRandom m where
     getRandomBytes :: ByteArray byteArray => Int -> m byteArray
 
 -- | A Deterministic Random Generator (DRG) class
@@ -27,6 +32,9 @@ class DRG gen where
 
 instance MonadRandom IO where
     getRandomBytes = getEntropy
+
+instance (MonadRandom m, MonadTrans t, Monad (t m)) => MonadRandom (t m) where
+  getRandomBytes = lift . getRandomBytes
 
 -- | A simple Monad class very similar to a State Monad
 -- with the state being a DRG.

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -245,6 +245,7 @@ Library
   Build-depends:     bytestring
                    , memory >= 0.14.18
                    , basement >= 0.0.6
+                   , transformers >= 0.2.0.0
                    , ghc-prim
   ghc-options:       -Wall -fwarn-tabs -optc-O3
   if os(linux)


### PR DESCRIPTION
It is common to use monad transformer stacks in applications, with
IO at the heart.  For applications using cryptonite, it is useful to
have MonadRandom instances for the common transformers.  Add the
instance

  instance (MonadRandom m, MonadTrans t, Monad (t m)) => MonadRandom (t m)

which achieves this with little code and one small additional
dependency, 'transformers', with no new transitive dependencies and
upon which many programs are likely to end up depending anyway.
Although new dependencies are discouraged, this change is motivated
by the usefulness of the instance and the desire to avoid orphan
instances in applications.

Also drive-by remove (Functor m) from MonadRandom class constraints,
because Functor is now a superclass of Monad and cryptonite no
longer supports pre-AMP GHC versions.

Fixes: https://github.com/haskell-crypto/cryptonite/issues/304