### PR TITLE
Fix support_sse on i386 architecture

### DIFF
--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -363,6 +363,8 @@ Library
 
   if arch(x86_64) || flag(support_sse)
     CPP-options:    -DSUPPORT_SSE
+    if arch(i386)
+      CC-options:   -msse2
 
   C-sources:      cbits/argon2/argon2.c
   include-dirs:   cbits/argon2


### PR DESCRIPTION
On i386 compilation failed with support_sse enabled and support_aesni disabled:

```
$ cabal configure -f-support_aesni -fsupport_sse
$ cabal build
[...]
In file included from cbits/blake2/sse/blake2b.c:23:0: error: 

cbits/blake2/sse/blake2-config.h:69:2: error:
     error: #error "This code requires at least SSE2."
     #error "This code requires at least SSE2."
      ^~~~~
   |
69 | #error "This code requires at least SSE2."
   |  ^
cbits/blake2/sse/blake2b.c: In function ‘blake2b_compress’:
```