### PR TITLE
AESNI and PCLMUL as per-function attributes

### DIFF
--- a/cbits/aes/x86ni.c
+++ b/cbits/aes/x86ni.c
@@ -30,6 +30,10 @@
 
 #ifdef WITH_AESNI
 
+#pragma GCC push_options
+#pragma GCC target("ssse3", "aes")
+#pragma clang attribute push (__attribute__((target("ssse3,aes"))), apply_to=function)
+
 #include <wmmintrin.h>
 #include <tmmintrin.h>
 #include <string.h>
@@ -399,5 +403,8 @@ static inline __m128i ghash_add(__m128i tag, const table_4bit htable, __m128i m)
 #undef DO_DEC_BLOCK
 
 #endif
+
+#pragma clang attribute pop
+#pragma GCC pop_options
 
 #endif

--- a/cbits/aes/x86ni.h
+++ b/cbits/aes/x86ni.h
@@ -40,8 +40,13 @@
 #include <cryptonite_aes.h>
 #include <aes/block128.h>
 
+#ifdef WITH_TARGET_ATTRIBUTES
 #define TARGET_AESNI __attribute__((target("ssse3,aes")))
 #define TARGET_AESNI_PCLMUL __attribute__((target("sse4.1,aes,pclmul")))
+#else
+#define TARGET_AESNI
+#define TARGET_AESNI_PCLMUL
+#endif
 
 #ifdef IMPL_DEBUG
 TARGET_AESNI

--- a/cbits/aes/x86ni.h
+++ b/cbits/aes/x86ni.h
@@ -40,7 +40,11 @@
 #include <cryptonite_aes.h>
 #include <aes/block128.h>
 
+#define TARGET_AESNI __attribute__((target("ssse3,aes")))
+#define TARGET_AESNI_PCLMUL __attribute__((target("sse4.1,aes,pclmul")))
+
 #ifdef IMPL_DEBUG
+TARGET_AESNI
 static void block128_sse_print(__m128i m)
 {
 	block128 b;

--- a/cbits/aes/x86ni_impl.c
+++ b/cbits/aes/x86ni_impl.c
@@ -28,6 +28,7 @@
  * SUCH DAMAGE.
  */
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_encrypt_block)(aes_block *out, aes_key *key, aes_block *in)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -37,6 +38,7 @@ void SIZED(cryptonite_aesni_encrypt_block)(aes_block *out, aes_key *key, aes_blo
 	_mm_storeu_si128((__m128i *) out, m);
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_decrypt_block)(aes_block *out, aes_key *key, aes_block *in)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -46,6 +48,7 @@ void SIZED(cryptonite_aesni_decrypt_block)(aes_block *out, aes_key *key, aes_blo
 	_mm_storeu_si128((__m128i *) out, m);
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_encrypt_ecb)(aes_block *out, aes_key *key, aes_block *in, uint32_t blocks)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -58,6 +61,7 @@ void SIZED(cryptonite_aesni_encrypt_ecb)(aes_block *out, aes_key *key, aes_block
 	}
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_decrypt_ecb)(aes_block *out, aes_key *key, aes_block *in, uint32_t blocks)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -71,6 +75,7 @@ void SIZED(cryptonite_aesni_decrypt_ecb)(aes_block *out, aes_key *key, aes_block
 	}
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_encrypt_cbc)(aes_block *out, aes_key *key, aes_block *_iv, aes_block *in, uint32_t blocks)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -87,6 +92,7 @@ void SIZED(cryptonite_aesni_encrypt_cbc)(aes_block *out, aes_key *key, aes_block
 	}
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_decrypt_cbc)(aes_block *out, aes_key *key, aes_block *_iv, aes_block *in, uint32_t blocks)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -106,6 +112,7 @@ void SIZED(cryptonite_aesni_decrypt_cbc)(aes_block *out, aes_key *key, aes_block
 	}
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_encrypt_ctr)(uint8_t *output, aes_key *key, aes_block *_iv, uint8_t *input, uint32_t len)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -151,6 +158,7 @@ void SIZED(cryptonite_aesni_encrypt_ctr)(uint8_t *output, aes_key *key, aes_bloc
 	return ;
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_encrypt_c32_)(uint8_t *output, aes_key *key, aes_block *_iv, uint8_t *input, uint32_t len)
 {
 	__m128i *k = (__m128i *) key->data;
@@ -192,6 +200,7 @@ void SIZED(cryptonite_aesni_encrypt_c32_)(uint8_t *output, aes_key *key, aes_blo
 	return ;
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_encrypt_xts)(aes_block *out, aes_key *key1, aes_key *key2,
                                aes_block *_tweak, uint32_t spoint, aes_block *in, uint32_t blocks)
 {
@@ -222,6 +231,7 @@ void SIZED(cryptonite_aesni_encrypt_xts)(aes_block *out, aes_key *key1, aes_key 
 	} while (0);
 }
 
+TARGET_AESNI
 void SIZED(cryptonite_aesni_gcm_encrypt)(uint8_t *output, aes_gcm *gcm, aes_key *key, uint8_t *input, uint32_t length)
 {
 	__m128i *k = (__m128i *) key->data;

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -105,7 +105,7 @@ Flag check_alignment
 
 Flag use_target_attributes
   Description:       use GCC / clang function attributes instead of global target options.
-  Default:           False
+  Default:           True
   Manual:            True
 
 Library

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -103,6 +103,11 @@ Flag check_alignment
   Default:           False
   Manual:            True
 
+Flag use_target_attributes
+  Description:       use GCC / clang function attributes instead of global target options.
+  Default:           False
+  Manual:            True
+
 Library
   Exposed-modules:   Crypto.Cipher.AES
                      Crypto.Cipher.AESGCMSIV
@@ -337,8 +342,12 @@ Library
 
   if flag(support_aesni) && (os(linux) || os(freebsd) || os(osx)) && (arch(i386) || arch(x86_64))
     CC-options:     -DWITH_AESNI
+    if !flag(use_target_attributes)
+      CC-options:     -mssse3 -maes
     if flag(support_pclmuldq)
       CC-options:   -DWITH_PCLMUL
+      if !flag(use_target_attributes)
+        CC-options:     -msse4.1 -mpclmul
     C-sources:       cbits/aes/x86ni.c
                    , cbits/aes/generic.c
                    , cbits/aes/gf.c
@@ -385,6 +394,8 @@ Library
     Build-depends:   deepseq
   if flag(check_alignment)
     cc-options:     -DWITH_ASSERT_ALIGNMENT
+  if flag(use_target_attributes)
+    cc-options:     -DWITH_TARGET_ATTRIBUTES
 
 Test-Suite test-cryptonite
   type:              exitcode-stdio-1.0

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -338,7 +338,7 @@ Library
   if flag(support_aesni) && (os(linux) || os(freebsd) || os(osx)) && (arch(i386) || arch(x86_64))
     CC-options:     -DWITH_AESNI
     if flag(support_pclmuldq)
-       CC-options:  -msse4.1 -mpclmul -DWITH_PCLMUL
+      CC-options:   -DWITH_PCLMUL
     C-sources:       cbits/aes/x86ni.c
                    , cbits/aes/generic.c
                    , cbits/aes/gf.c

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -336,7 +336,7 @@ Library
     c-sources:      cbits/cryptonite_rdrand.c
 
   if flag(support_aesni) && (os(linux) || os(freebsd) || os(osx)) && (arch(i386) || arch(x86_64))
-    CC-options:     -mssse3 -maes -DWITH_AESNI
+    CC-options:     -DWITH_AESNI
     if flag(support_pclmuldq)
        CC-options:  -msse4.1 -mpclmul -DWITH_PCLMUL
     C-sources:       cbits/aes/x86ni.c


### PR DESCRIPTION
In #314 was confirmed that flag support_aesni causes runtime failures in code not related to AES-NI with i386/amd64 processor not supporting SSSE3. This comes from the use of option `-mssse3` at compile time, enabled for all C source files.

The PR adds an optional package flag to use instead function attributes, enabling the necessary target options where necessary, which means only in parts of the code protected with runtime CPU detection. The flag can be enabled in distributions when wanting broad CPU support and knowing the C compiler is compatible.

Mechanism known to be supported with:
- GCC >= 4.4 (released in 2009, see [changes](https://gcc.gnu.org/gcc-4.4/changes.html))
- clang >= 3.7 (released in 2015, see [docs](https://releases.llvm.org/3.7.0/tools/clang/docs/AttributeReference.html#target-gnu-target))

Related to:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=869096
- https://github.com/NixOS/nixpkgs/issues/81915
- https://github.com/haskell/cabal/issues/4294