### PR TITLE
Hashing independent from input length

### DIFF
--- a/Crypto/Hash/Algorithms.hs
+++ b/Crypto/Hash/Algorithms.hs
@@ -9,6 +9,7 @@
 --
 module Crypto.Hash.Algorithms
     ( HashAlgorithm
+    , HashAlgorithmPrefix
     -- * Hash algorithms
     , Blake2s_160(..)
     , Blake2s_224(..)
@@ -54,7 +55,7 @@ module Crypto.Hash.Algorithms
     , Whirlpool(..)
     ) where
 
-import           Crypto.Hash.Types (HashAlgorithm)
+import           Crypto.Hash.Types (HashAlgorithm, HashAlgorithmPrefix)
 import           Crypto.Hash.Blake2s
 import           Crypto.Hash.Blake2sp
 import           Crypto.Hash.Blake2b

--- a/Crypto/Hash/MD5.hs
+++ b/Crypto/Hash/MD5.hs
@@ -34,6 +34,9 @@ instance HashAlgorithm MD5 where
     hashInternalUpdate        = c_md5_update
     hashInternalFinalize      = c_md5_finalize
 
+instance HashAlgorithmPrefix MD5 where
+    hashInternalFinalizePrefix = c_md5_finalize_prefix
+
 foreign import ccall unsafe "cryptonite_md5_init"
     c_md5_init :: Ptr (Context a)-> IO ()
 
@@ -42,3 +45,6 @@ foreign import ccall "cryptonite_md5_update"
 
 foreign import ccall unsafe "cryptonite_md5_finalize"
     c_md5_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+foreign import ccall "cryptonite_md5_finalize_prefix"
+    c_md5_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()

--- a/Crypto/Hash/SHA1.hs
+++ b/Crypto/Hash/SHA1.hs
@@ -34,6 +34,9 @@ instance HashAlgorithm SHA1 where
     hashInternalUpdate        = c_sha1_update
     hashInternalFinalize      = c_sha1_finalize
 
+instance HashAlgorithmPrefix SHA1 where
+    hashInternalFinalizePrefix = c_sha1_finalize_prefix
+
 foreign import ccall unsafe "cryptonite_sha1_init"
     c_sha1_init :: Ptr (Context a)-> IO ()
 
@@ -42,3 +45,6 @@ foreign import ccall "cryptonite_sha1_update"
 
 foreign import ccall unsafe "cryptonite_sha1_finalize"
     c_sha1_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+foreign import ccall "cryptonite_sha1_finalize_prefix"
+    c_sha1_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()

--- a/Crypto/Hash/SHA224.hs
+++ b/Crypto/Hash/SHA224.hs
@@ -34,6 +34,9 @@ instance HashAlgorithm SHA224 where
     hashInternalUpdate        = c_sha224_update
     hashInternalFinalize      = c_sha224_finalize
 
+instance HashAlgorithmPrefix SHA224 where
+    hashInternalFinalizePrefix = c_sha224_finalize_prefix
+
 foreign import ccall unsafe "cryptonite_sha224_init"
     c_sha224_init :: Ptr (Context a)-> IO ()
 
@@ -42,3 +45,6 @@ foreign import ccall "cryptonite_sha224_update"
 
 foreign import ccall unsafe "cryptonite_sha224_finalize"
     c_sha224_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+foreign import ccall "cryptonite_sha224_finalize_prefix"
+    c_sha224_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()

--- a/Crypto/Hash/SHA256.hs
+++ b/Crypto/Hash/SHA256.hs
@@ -34,6 +34,9 @@ instance HashAlgorithm SHA256 where
     hashInternalUpdate        = c_sha256_update
     hashInternalFinalize      = c_sha256_finalize
 
+instance HashAlgorithmPrefix SHA256 where
+    hashInternalFinalizePrefix = c_sha256_finalize_prefix
+
 foreign import ccall unsafe "cryptonite_sha256_init"
     c_sha256_init :: Ptr (Context a)-> IO ()
 
@@ -42,3 +45,6 @@ foreign import ccall "cryptonite_sha256_update"
 
 foreign import ccall unsafe "cryptonite_sha256_finalize"
     c_sha256_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+foreign import ccall "cryptonite_sha256_finalize_prefix"
+    c_sha256_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()

--- a/Crypto/Hash/SHA384.hs
+++ b/Crypto/Hash/SHA384.hs
@@ -34,6 +34,9 @@ instance HashAlgorithm SHA384 where
     hashInternalUpdate        = c_sha384_update
     hashInternalFinalize      = c_sha384_finalize
 
+instance HashAlgorithmPrefix SHA384 where
+    hashInternalFinalizePrefix = c_sha384_finalize_prefix
+
 foreign import ccall unsafe "cryptonite_sha384_init"
     c_sha384_init :: Ptr (Context a)-> IO ()
 
@@ -42,3 +45,6 @@ foreign import ccall "cryptonite_sha384_update"
 
 foreign import ccall unsafe "cryptonite_sha384_finalize"
     c_sha384_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+foreign import ccall "cryptonite_sha384_finalize_prefix"
+    c_sha384_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()

--- a/Crypto/Hash/SHA512.hs
+++ b/Crypto/Hash/SHA512.hs
@@ -34,6 +34,9 @@ instance HashAlgorithm SHA512 where
     hashInternalUpdate        = c_sha512_update
     hashInternalFinalize      = c_sha512_finalize
 
+instance HashAlgorithmPrefix SHA512 where
+    hashInternalFinalizePrefix = c_sha512_finalize_prefix
+
 foreign import ccall unsafe "cryptonite_sha512_init"
     c_sha512_init :: Ptr (Context a)-> IO ()
 
@@ -42,3 +45,6 @@ foreign import ccall "cryptonite_sha512_update"
 
 foreign import ccall unsafe "cryptonite_sha512_finalize"
     c_sha512_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+foreign import ccall "cryptonite_sha512_finalize_prefix"
+    c_sha512_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()

--- a/Crypto/Hash/Types.hs
+++ b/Crypto/Hash/Types.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module Crypto.Hash.Types
     ( HashAlgorithm(..)
+    , HashAlgorithmPrefix(..)
     , Context(..)
     , Digest(..)
     ) where
@@ -58,6 +59,17 @@ class HashAlgorithm a where
     hashInternalUpdate   :: Ptr (Context a) -> Ptr Word8 -> Word32 -> IO ()
     -- | Finalize the context and set the digest raw memory to the right value
     hashInternalFinalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+
+-- | Hashing algorithms with a constant-time implementation.
+class HashAlgorithm a => HashAlgorithmPrefix a where
+    -- | Update the context with the first N bytes of a buffer and finalize this
+    -- context.  The code path executed is independent from N and depends only
+    -- on the complete buffer length.
+    hashInternalFinalizePrefix :: Ptr (Context a)
+                               -> Ptr Word8 -> Word32
+                               -> Word32
+                               -> Ptr (Digest a)
+                               -> IO ()
 
 {-
 hashContextGetAlgorithm :: HashAlgorithm a => Context a -> a

--- a/cbits/cryptonite_align.h
+++ b/cbits/cryptonite_align.h
@@ -44,9 +44,19 @@ static inline void store_le32_aligned(uint8_t *dst, const uint32_t v)
 	*((uint32_t *) dst) = cpu_to_le32(v);
 }
 
+static inline void xor_le32_aligned(uint8_t *dst, const uint32_t v)
+{
+	*((uint32_t *) dst) ^= cpu_to_le32(v);
+}
+
 static inline void store_be32_aligned(uint8_t *dst, const uint32_t v)
 {
 	*((uint32_t *) dst) = cpu_to_be32(v);
+}
+
+static inline void xor_be32_aligned(uint8_t *dst, const uint32_t v)
+{
+	*((uint32_t *) dst) ^= cpu_to_be32(v);
 }
 
 static inline void store_le64_aligned(uint8_t *dst, const uint64_t v)
@@ -57,6 +67,11 @@ static inline void store_le64_aligned(uint8_t *dst, const uint64_t v)
 static inline void store_be64_aligned(uint8_t *dst, const uint64_t v)
 {
 	*((uint64_t *) dst) = cpu_to_be64(v);
+}
+
+static inline void xor_be64_aligned(uint8_t *dst, const uint64_t v)
+{
+	*((uint64_t *) dst) ^= cpu_to_be64(v);
 }
 
 #ifdef UNALIGNED_ACCESS_OK
@@ -70,19 +85,29 @@ static inline uint32_t load_le32(const uint8_t *p)
 
 #ifdef UNALIGNED_ACCESS_OK
 #define store_le32(a, b) store_le32_aligned(a, b)
+#define xor_le32(a, b) xor_le32_aligned(a, b)
 #else
 static inline void store_le32(uint8_t *dst, const uint32_t v)
 {
 	dst[0] = v; dst[1] = v >> 8; dst[2] = v >> 16; dst[3] = v >> 24;
 }
+static inline void xor_le32(uint8_t *dst, const uint32_t v)
+{
+	dst[0] ^= v; dst[1] ^= v >> 8; dst[2] ^= v >> 16; dst[3] ^= v >> 24;
+}
 #endif
 
 #ifdef UNALIGNED_ACCESS_OK
 #define store_be32(a, b) store_be32_aligned(a, b)
+#define xor_be32(a, b) xor_be32_aligned(a, b)
 #else
 static inline void store_be32(uint8_t *dst, const uint32_t v)
 {
 	dst[3] = v; dst[2] = v >> 8; dst[1] = v >> 16; dst[0] = v >> 24;
+}
+static inline void xor_be32(uint8_t *dst, const uint32_t v)
+{
+	dst[3] ^= v; dst[2] ^= v >> 8; dst[1] ^= v >> 16; dst[0] ^= v >> 24;
 }
 #endif
 
@@ -98,11 +123,17 @@ static inline void store_le64(uint8_t *dst, const uint64_t v)
 
 #ifdef UNALIGNED_ACCESS_OK
 #define store_be64(a, b) store_be64_aligned(a, b)
+#define xor_be64(a, b) xor_be64_aligned(a, b)
 #else
 static inline void store_be64(uint8_t *dst, const uint64_t v)
 {
 	dst[7] = v      ; dst[6] = v >> 8 ; dst[5] = v >> 16; dst[4] = v >> 24;
 	dst[3] = v >> 32; dst[2] = v >> 40; dst[1] = v >> 48; dst[0] = v >> 56;
+}
+static inline void xor_be64(uint8_t *dst, const uint64_t v)
+{
+	dst[7] ^= v      ; dst[6] ^= v >> 8 ; dst[5] ^= v >> 16; dst[4] ^= v >> 24;
+	dst[3] ^= v >> 32; dst[2] ^= v >> 40; dst[1] ^= v >> 48; dst[0] ^= v >> 56;
 }
 #endif
 

--- a/cbits/cryptonite_hash_prefix.c
+++ b/cbits/cryptonite_hash_prefix.c
@@ -63,7 +63,7 @@ void CRYPTONITE_HASHED(finalize_prefix)(struct HASHED_LOWER(ctx) *ctx, const uin
 			b = 0;
 
 		/* First padding byte */
-		b |= 0x80 & (uint8_t) constant_time_eq(pos, n);;
+		b |= 0x80 & (uint8_t) constant_time_eq(pos, n);
 
 		/* Size bytes are always at the end of a block */
 		if (index >= cut_off)

--- a/cbits/cryptonite_hash_prefix.c
+++ b/cbits/cryptonite_hash_prefix.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Olivier Chéron <olivier.cheron@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cryptonite_hash_prefix.h>
+
+void CRYPTONITE_HASHED(finalize_prefix)(struct HASHED_LOWER(ctx) *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out)
+{
+	uint64_t bits[HASHED(BITS_ELEMS)];
+	uint8_t *p = (uint8_t *) &bits;
+	uint32_t index, padidx, padlen, pos, out_mask;
+	static const uint32_t cut_off = HASHED(BLOCK_SIZE) - sizeof(bits);
+
+	/* Make sure n <= len */
+	n += (len - n) & constant_time_lt(len, n);
+
+	/* Initial index, based on current context state */
+	index = CRYPTONITE_HASHED(get_index)(ctx);
+
+	/* Final size after n bytes */
+	CRYPTONITE_HASHED(incr_sz)(ctx, bits, n);
+
+	/* Padding index and length */
+	padidx = CRYPTONITE_HASHED(get_index)(ctx);
+	padlen = HASHED(BLOCK_SIZE) + cut_off - padidx;
+	padlen -= HASHED(BLOCK_SIZE) & constant_time_lt(padidx, cut_off);
+
+	/* Initialize buffers because we will XOR into them */
+	memset(ctx->buf + index, 0, HASHED(BLOCK_SIZE) - index);
+	memset(out, 0, HASHED(DIGEST_SIZE));
+	pos = 0;
+
+	/* Iterate based on the full buffer length, regardless of n, and include
+	 * the maximum overhead with padding and size bytes
+	 */
+	while (pos < len + HASHED(BLOCK_SIZE) + sizeof(bits)) {
+		uint8_t b;
+
+		/* Take as many bytes from the input buffer as possible */
+		if (pos < len)
+			b = *(data++) & (uint8_t) constant_time_lt(pos, n);
+		else
+			b = 0;
+
+		/* First padding byte */
+		b |= 0x80 & (uint8_t) constant_time_eq(pos, n);;
+
+		/* Size bytes are always at the end of a block */
+		if (index >= cut_off)
+			b |= p[index - cut_off] & (uint8_t) constant_time_ge(pos, n + padlen);
+
+		/* Store this byte into the buffer */
+		ctx->buf[index++] ^= b;
+		pos++;
+
+		/* Process a full block, at a boundary which is independent from n */
+		if (index >= HASHED(BLOCK_SIZE)) {
+			index = 0;
+			HASHED_LOWER(do_chunk)(ctx, (void *) ctx->buf);
+			memset(ctx->buf, 0, HASHED(BLOCK_SIZE));
+
+			/* Try to store the result: this is a no-op except when we reach the
+			 * actual size based on n, more iterations may continue after that
+			 * when len is really larger
+			 */
+			out_mask = constant_time_eq(pos, n + padlen + sizeof(bits));
+			CRYPTONITE_HASHED(select_digest)(ctx, out, out_mask);
+		}
+	}
+}

--- a/cbits/cryptonite_hash_prefix.h
+++ b/cbits/cryptonite_hash_prefix.h
@@ -1,14 +1,14 @@
 /*
- * Copyright (C) 2006-2009 Vincent Hanquez <vincent@snarc.org>
+ * Copyright (C) 2020 Olivier Chéron <olivier.cheron@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
+ *	notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *	notice, this list of conditions and the following disclaimer in the
+ *	documentation and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
@@ -21,26 +21,45 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef CRYPTOHASH_SHA1_H
-#define CRYPTOHASH_SHA1_H
+
+#ifndef CRYPTONITE_HASH_PREFIX_H
+#define CRYPTONITE_HASH_PREFIX_H
 
 #include <stdint.h>
 
-# define SHA1_BLOCK_SIZE 64
-
-struct sha1_ctx
+static inline uint32_t constant_time_msb(uint32_t a)
 {
-	uint64_t sz;
-	uint8_t  buf[SHA1_BLOCK_SIZE];
-	uint32_t h[5];
-};
+	return 0 - (a >> 31);
+}
 
-#define SHA1_DIGEST_SIZE	20
-#define SHA1_CTX_SIZE 		(sizeof(struct sha1_ctx))
+static inline uint32_t constant_time_lt(uint32_t a, uint32_t b)
+{
+	return constant_time_msb(a ^ ((a ^ b) | ((a - b) ^ b)));
+}
 
-void cryptonite_sha1_init(struct sha1_ctx *ctx);
-void cryptonite_sha1_update(struct sha1_ctx *ctx, const uint8_t *data, uint32_t len);
-void cryptonite_sha1_finalize(struct sha1_ctx *ctx, uint8_t *out);
-void cryptonite_sha1_finalize_prefix(struct sha1_ctx *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out);
+static inline uint32_t constant_time_ge(uint32_t a, uint32_t b)
+{
+	return ~constant_time_lt(a, b);
+}
+
+static inline uint32_t constant_time_is_zero(uint32_t a)
+{
+	return constant_time_msb(~a & (a - 1));
+}
+
+static inline uint32_t constant_time_eq(uint32_t a, uint32_t b)
+{
+	return constant_time_is_zero(a ^ b);
+}
+
+static inline uint64_t constant_time_msb_64(uint64_t a)
+{
+	return 0 - (a >> 63);
+}
+
+static inline uint64_t constant_time_lt_64(uint64_t a, uint64_t b)
+{
+	return constant_time_msb_64(a ^ ((a ^ b) | ((a - b) ^ b)));
+}
 
 #endif

--- a/cbits/cryptonite_md5.c
+++ b/cbits/cryptonite_md5.c
@@ -185,3 +185,30 @@ void cryptonite_md5_finalize(struct md5_ctx *ctx, uint8_t *out)
 	store_le32(out+ 8, ctx->h[2]);
 	store_le32(out+12, ctx->h[3]);
 }
+
+#define HASHED(m) MD5_##m
+#define HASHED_LOWER(m) md5_##m
+#define CRYPTONITE_HASHED(m) cryptonite_md5_##m
+#define MD5_BLOCK_SIZE 64
+#define MD5_BITS_ELEMS 1
+
+static inline uint32_t cryptonite_md5_get_index(const struct md5_ctx *ctx)
+{
+	return (uint32_t) (ctx->sz & 0x3f);
+}
+
+static inline void cryptonite_md5_incr_sz(struct md5_ctx *ctx, uint64_t *bits, uint32_t n)
+{
+	ctx->sz += n;
+	*bits = cpu_to_le64(ctx->sz << 3);
+}
+
+static inline void cryptonite_md5_select_digest(const struct md5_ctx *ctx, uint8_t *out, uint32_t out_mask)
+{
+	xor_le32(out   , ctx->h[0] & out_mask);
+	xor_le32(out+ 4, ctx->h[1] & out_mask);
+	xor_le32(out+ 8, ctx->h[2] & out_mask);
+	xor_le32(out+12, ctx->h[3] & out_mask);
+}
+
+#include <cryptonite_hash_prefix.c>

--- a/cbits/cryptonite_md5.h
+++ b/cbits/cryptonite_md5.h
@@ -39,5 +39,6 @@ struct md5_ctx
 void cryptonite_md5_init(struct md5_ctx *ctx);
 void cryptonite_md5_update(struct md5_ctx *ctx, const uint8_t *data, uint32_t len);
 void cryptonite_md5_finalize(struct md5_ctx *ctx, uint8_t *out);
+void cryptonite_md5_finalize_prefix(struct md5_ctx *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out);
 
 #endif

--- a/cbits/cryptonite_sha1.c
+++ b/cbits/cryptonite_sha1.c
@@ -216,3 +216,31 @@ void cryptonite_sha1_finalize(struct sha1_ctx *ctx, uint8_t *out)
 	store_be32(out+12, ctx->h[3]);
 	store_be32(out+16, ctx->h[4]);
 }
+
+#define HASHED(m) SHA1_##m
+#define HASHED_LOWER(m) sha1_##m
+#define CRYPTONITE_HASHED(m) cryptonite_sha1_##m
+#define SHA1_BLOCK_SIZE 64
+#define SHA1_BITS_ELEMS 1
+
+static inline uint32_t cryptonite_sha1_get_index(const struct sha1_ctx *ctx)
+{
+	return (uint32_t) (ctx->sz & 0x3f);
+}
+
+static inline void cryptonite_sha1_incr_sz(struct sha1_ctx *ctx, uint64_t *bits, uint32_t n)
+{
+	ctx->sz += n;
+	*bits = cpu_to_be64(ctx->sz << 3);
+}
+
+static inline void cryptonite_sha1_select_digest(const struct sha1_ctx *ctx, uint8_t *out, uint32_t out_mask)
+{
+	xor_be32(out   , ctx->h[0] & out_mask);
+	xor_be32(out+ 4, ctx->h[1] & out_mask);
+	xor_be32(out+ 8, ctx->h[2] & out_mask);
+	xor_be32(out+12, ctx->h[3] & out_mask);
+	xor_be32(out+16, ctx->h[4] & out_mask);
+}
+
+#include <cryptonite_hash_prefix.c>

--- a/cbits/cryptonite_sha256.h
+++ b/cbits/cryptonite_sha256.h
@@ -47,9 +47,11 @@ struct sha256_ctx
 void cryptonite_sha224_init(struct sha224_ctx *ctx);
 void cryptonite_sha224_update(struct sha224_ctx *ctx, const uint8_t *data, uint32_t len);
 void cryptonite_sha224_finalize(struct sha224_ctx *ctx, uint8_t *out);
+void cryptonite_sha224_finalize_prefix(struct sha224_ctx *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out);
 
 void cryptonite_sha256_init(struct sha256_ctx *ctx);
 void cryptonite_sha256_update(struct sha256_ctx *ctx, const uint8_t *data, uint32_t len);
 void cryptonite_sha256_finalize(struct sha256_ctx *ctx, uint8_t *out);
+void cryptonite_sha256_finalize_prefix(struct sha256_ctx *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out);
 
 #endif

--- a/cbits/cryptonite_sha512.h
+++ b/cbits/cryptonite_sha512.h
@@ -46,10 +46,12 @@ struct sha512_ctx
 void cryptonite_sha384_init(struct sha384_ctx *ctx);
 void cryptonite_sha384_update(struct sha384_ctx *ctx, const uint8_t *data, uint32_t len);
 void cryptonite_sha384_finalize(struct sha384_ctx *ctx, uint8_t *out);
+void cryptonite_sha384_finalize_prefix(struct sha384_ctx *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out);
 
 void cryptonite_sha512_init(struct sha512_ctx *ctx);
 void cryptonite_sha512_update(struct sha512_ctx *ctx, const uint8_t *data, uint32_t len);
 void cryptonite_sha512_finalize(struct sha512_ctx *ctx, uint8_t *out);
+void cryptonite_sha512_finalize_prefix(struct sha512_ctx *ctx, const uint8_t *data, uint32_t len, uint32_t n, uint8_t *out);
 
 /* only multiples of 8 are supported as valid t values */
 void cryptonite_sha512t_init(struct sha512_ctx *ctx, uint32_t hashlen);

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -57,6 +57,7 @@ extra-source-files:  cbits/*.h
                      cbits/argon2/*.h
                      cbits/argon2/*.c
                      cbits/aes/x86ni_impl.c
+                     cbits/cryptonite_hash_prefix.c
                      tests/*.hs
 
 source-repository head

--- a/gen/Template.hs
+++ b/gen/Template.hs
@@ -45,7 +45,7 @@ renderTemplate template attrs multiAttrs =
         renderAtom (Tpl n t) =
             case lookup n multiAttrs of
                 Nothing     -> error ("cannot find inner template attributes for: " ++ n)
-                Just []     -> error ("empty multiattrs for: " ++ n)
+                Just []     -> ""
                 Just (i:is) ->
                     renderTemplate t (i ++ attrs) [] ++
                     concatMap (\inAttrs -> renderTemplate t (inAttrs ++ attrs ++ [("COMMA", ",")]) []) is

--- a/gen/template/hash.hs
+++ b/gen/template/hash.hs
@@ -32,7 +32,10 @@ instance HashAlgorithm %%MODULENAME%% where
     hashInternalContextSize _ = %%CTX_SIZE_BYTES%%
     hashInternalInit          = c_%%HASHNAME%%_init
     hashInternalUpdate        = c_%%HASHNAME%%_update
-    hashInternalFinalize      = c_%%HASHNAME%%_finalize
+    hashInternalFinalize      = c_%%HASHNAME%%_finalize%{HASPREFIXINSTANCE%}
+
+instance HashAlgorithmPrefix %%MODULENAME%% where
+    hashInternalFinalizePrefix = c_%%HASHNAME%%_finalize_prefix%{HASPREFIXINSTANCE%}
 
 foreign import ccall unsafe "cryptonite_%%HASHNAME%%_init"
     c_%%HASHNAME%%_init :: Ptr (Context a)-> IO ()
@@ -41,4 +44,7 @@ foreign import ccall "cryptonite_%%HASHNAME%%_update"
     c_%%HASHNAME%%_update :: Ptr (Context a) -> Ptr Word8 -> Word32 -> IO ()
 
 foreign import ccall unsafe "cryptonite_%%HASHNAME%%_finalize"
-    c_%%HASHNAME%%_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()
+    c_%%HASHNAME%%_finalize :: Ptr (Context a) -> Ptr (Digest a) -> IO ()%{HASPREFIXINSTANCE%}
+
+foreign import ccall "cryptonite_%%HASHNAME%%_finalize_prefix"
+    c_%%HASHNAME%%_finalize_prefix :: Ptr (Context a) -> Ptr Word8 -> Word32 -> Word32 -> Ptr (Digest a) -> IO ()%{HASPREFIXINSTANCE%}

--- a/tests/Hash.hs
+++ b/tests/Hash.hs
@@ -221,6 +221,24 @@ runhashinc :: HashAlg -> [ByteString] -> ByteString
 runhashinc (HashAlg hashAlg) v = B.convertToBase B.Base16 $ hashinc $ v
   where hashinc = hashFinalize . foldl hashUpdate (hashInitWith hashAlg)
 
+data HashPrefixAlg = forall alg . HashAlgorithmPrefix alg => HashPrefixAlg alg
+
+expectedPrefix :: [ (String, HashPrefixAlg) ]
+expectedPrefix =
+    [ ("MD5", HashPrefixAlg MD5)
+    , ("SHA1", HashPrefixAlg SHA1)
+    , ("SHA224", HashPrefixAlg SHA224)
+    , ("SHA256", HashPrefixAlg SHA256)
+    , ("SHA384", HashPrefixAlg SHA384)
+    , ("SHA512", HashPrefixAlg SHA512)
+    ]
+
+runhashpfx :: HashPrefixAlg -> ByteString -> ByteString
+runhashpfx (HashPrefixAlg hashAlg) v = B.convertToBase B.Base16 $ hashWith hashAlg v
+
+runhashpfxpfx :: HashPrefixAlg -> ByteString -> Int -> ByteString
+runhashpfxpfx (HashPrefixAlg hashAlg) v len = B.convertToBase B.Base16 $ hashPrefixWith hashAlg v len
+
 makeTestAlg (name, hashAlg, results) =
     testGroup name $ concatMap maketest (zip3 is vectors results)
   where
@@ -234,6 +252,19 @@ makeTestAlg (name, hashAlg, results) =
 makeTestChunk (hashName, hashAlg, _) =
     [ testProperty hashName $ \ckLen (ArbitraryBS0_2901 inp) ->
         runhash hashAlg inp `propertyEq` runhashinc hashAlg (chunkS ckLen inp)
+    ]
+
+makeTestPrefix (hashName, hashAlg) =
+    [ testProperty hashName $ \(ArbitraryBS0_2901 inp) (Int0_2901 len) ->
+        runhashpfx hashAlg (B.take len inp) `propertyEq` runhashpfxpfx hashAlg inp len
+    ]
+
+makeTestHybrid (hashName, HashPrefixAlg alg) =
+    [ testProperty hashName $ \(ArbitraryBS0_2901 start) (ArbitraryBS0_2901 end) -> do
+        len <- choose (0, B.length end)
+        let ref = hashWith alg (start `B.append` B.take len end)
+            hyb = hashFinalizePrefix (hashUpdate (hashInitWith alg) start) end len
+        return (ref `propertyEq` hyb)
     ]
 
 -- SHAKE128 truncation example with expected byte at final position
@@ -253,6 +284,8 @@ makeTestSHAKE128Truncation i byte =
 tests = testGroup "hash"
     [ testGroup "KATs" (map makeTestAlg expected)
     , testGroup "Chunking" (concatMap makeTestChunk expected)
+    , testGroup "Prefix" (concatMap makeTestPrefix expectedPrefix)
+    , testGroup "Hybrid" (concatMap makeTestHybrid expectedPrefix)
     , testGroup "Truncating"
         [ testGroup "SHAKE128"
             (zipWith makeTestSHAKE128Truncation [1..] shake128TruncationBytes)


### PR DESCRIPTION
Extends the hash API and some implementations to add a primitive with a code path independent from the message length.
The number of compression-function calls and all internal padding logic depends on the total buffer length, but not the effective message length specified as additional argument.

One typical application is decoding a MAC-then-Encrypt construction after block-cipher decryption, like CBC mode in TLS.
All validation code should run in constant-time, otherwise this can lead to distinguishing or plaintext-recovery attacks.