### PR TITLE
Add Entropy source using getrandom()

### DIFF
--- a/Crypto/Random/Entropy/Backend.hs
+++ b/Crypto/Random/Entropy/Backend.hs
@@ -22,6 +22,8 @@ import Crypto.Random.Entropy.RDRand
 #endif
 #ifdef WINDOWS
 import Crypto.Random.Entropy.Windows
+#elif defined SUPPORT_GETRANDOM
+import Crypto.Random.Entropy.GetRandom
 #else
 import Crypto.Random.Entropy.Unix
 #endif
@@ -35,6 +37,8 @@ supportedBackends =
 #endif
 #ifdef WINDOWS
     openBackend (Proxy :: Proxy WinCryptoAPI)
+#elif defined SUPPORT_GETRANDOM
+    openBackend (Proxy :: Proxy GetRandom)
 #else
     openBackend (Proxy :: Proxy DevRandom), openBackend (Proxy :: Proxy DevURandom)
 #endif

--- a/Crypto/Random/Entropy/GetRandom.hs
+++ b/Crypto/Random/Entropy/GetRandom.hs
@@ -1,0 +1,24 @@
+module Crypto.Random.Entropy.GetRandom (GetRandom(..)) where
+
+import Foreign.Ptr (Ptr)
+import Foreign.C.Types (CSize(..), CUInt(..))
+import Foreign.C.Error (throwErrnoIf)
+import Data.Word (Word8)
+import Crypto.Random.Entropy.Source
+
+foreign import ccall unsafe "getrandom"
+  c_getrandom :: Ptr Word8 -> CSize -> CUInt -> IO CSize
+
+data GetRandom = GetRandom
+
+instance EntropySource GetRandom where
+  entropyOpen     = return $ Just GetRandom
+  entropyGather _ = getRandomBytes
+  entropyClose _  = return ()
+
+getRandomBytes :: Ptr Word8 -> Int -> IO Int
+getRandomBytes ptr sz = 
+      throwErrnoIf (< 0) "getrandom()"
+  $   fromIntegral
+  <$> c_getrandom ptr (fromIntegral sz) 0
+

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -109,6 +109,11 @@ Flag use_target_attributes
   Default:           True
   Manual:            True
 
+Flag support_getrandom
+  Description:       use Linux getrandom syscall
+  Default:           True
+  Manual:            True
+
 Library
   Exposed-modules:   Crypto.Cipher.AES
                      Crypto.Cipher.AESGCMSIV
@@ -340,6 +345,10 @@ Library
     CPP-options:    -DSUPPORT_RDRAND
     Other-modules:  Crypto.Random.Entropy.RDRand
     c-sources:      cbits/cryptonite_rdrand.c
+
+  if flag(support_getrandom) && os(linux)
+    CPP-options:    -DSUPPORT_GETRANDOM
+    Other-modules:  Crypto.Random.Entropy.GetRandom
 
   if flag(support_aesni) && (os(linux) || os(freebsd) || os(osx)) && (arch(i386) || arch(x86_64))
     CC-options:     -DWITH_AESNI


### PR DESCRIPTION
This PR addresses #255 by implementing getrandom and, depending on a flag, replacing `/dev/random` and `/dev/urandom` as entropy sources with the `getrandom()` syscall.

`getrandom()` is strictly better than /dev/random or /dev/urandom. It will block on systems with uninitialized entropy pools, but will not block thereafter, and pulls from the same entropy pool as `/dev/urandom`. Thus, it does not block after system entropy initialization, like `/dev/random` does, and it does not provide "bad" entropy prior to system entropy initialization, like `/dev/urandom` does.

It is also not vulnerable to file descriptor exhaustion, as it does not use filehandles to read from the stream devices, but instead generates bytes directly from the kernel entropy pool and copies them into the provided buffer.