### PR TITLE
Fix alignment in gfmul_generic (closes #334)

### DIFF
--- a/cbits/aes/x86ni.c
+++ b/cbits/aes/x86ni.c
@@ -165,7 +165,7 @@ static __m128i gfmulx(__m128i v)
 TARGET_AESNI
 static __m128i gfmul_generic(__m128i tag, const table_4bit htable)
 {
-	aes_block _t;
+	aes_block _t ALIGNMENT(16);
 	_mm_store_si128((__m128i *) &_t, tag);
 	cryptonite_aes_generic_gf_mul(&_t, htable);
 	tag = _mm_load_si128((__m128i *) &_t);


### PR DESCRIPTION
I believe this is the root of #334, though it would be good to get confirmation.

This fixes a test-suite segfault on Darwin with -O0. Before this change:

```
$ cabal run -O0 test-cryptonite -- -p AE1
Segmentation fault: 11
```

with

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   test-cryptonite               	0x0000000108f7f61f gfmul_generic + 47
1   test-cryptonite               	0x0000000108f76f17 ghash_add + 71
2   test-cryptonite               	0x0000000108f743b4 cryptonite_aesni_gcm_encrypt128 + 2244
3   test-cryptonite               	0x0000000108f97f20 cryptonite_aes_gcm_encrypt + 96
4   test-cryptonite               	0x0000000108eeadf5 Lc8Pq_info + 197
```