### PR TITLE
Linker complaints

### DIFF
--- a/cbits/argon2/core.c
+++ b/cbits/argon2/core.c
@@ -4,7 +4,7 @@
  * Copyright 2015
  * Daniel Dinu, Dmitry Khovratovich, Jean-Philippe Aumasson, and Samuel Neves
  *
- * You may use this work under the terms of a Creative Commons CC0 1.0 
+ * You may use this work under the terms of a Creative Commons CC0 1.0
  * License/Waiver or the Apache Public License 2.0, at your option. The terms of
  * these licenses can be found at:
  *
@@ -83,25 +83,25 @@ static int blake2b_long(void *pout, size_t outlen, const void *in, size_t inlen)
     } while ((void)0, 0)
 
     if (outlen <= BLAKE2B_OUTBYTES) {
-        TRY(blake2b_init(&blake_state, outlen));
-        TRY(blake2b_update(&blake_state, outlen_bytes, sizeof(outlen_bytes)));
-        TRY(blake2b_update(&blake_state, in, inlen));
-        TRY(blake2b_final(&blake_state, out, outlen));
+        TRY(_cryptonite_blake2b_init(&blake_state, outlen));
+        TRY(_cryptonite_blake2b_update(&blake_state, outlen_bytes, sizeof(outlen_bytes)));
+        TRY(_cryptonite_blake2b_update(&blake_state, in, inlen));
+        TRY(_cryptonite_blake2b_final(&blake_state, out, outlen));
     } else {
         uint32_t toproduce;
         uint8_t out_buffer[BLAKE2B_OUTBYTES];
         uint8_t in_buffer[BLAKE2B_OUTBYTES];
-        TRY(blake2b_init(&blake_state, BLAKE2B_OUTBYTES));
-        TRY(blake2b_update(&blake_state, outlen_bytes, sizeof(outlen_bytes)));
-        TRY(blake2b_update(&blake_state, in, inlen));
-        TRY(blake2b_final(&blake_state, out_buffer, BLAKE2B_OUTBYTES));
+        TRY(_cryptonite_blake2b_init(&blake_state, BLAKE2B_OUTBYTES));
+        TRY(_cryptonite_blake2b_update(&blake_state, outlen_bytes, sizeof(outlen_bytes)));
+        TRY(_cryptonite_blake2b_update(&blake_state, in, inlen));
+        TRY(_cryptonite_blake2b_final(&blake_state, out_buffer, BLAKE2B_OUTBYTES));
         memcpy(out, out_buffer, BLAKE2B_OUTBYTES / 2);
         out += BLAKE2B_OUTBYTES / 2;
         toproduce = (uint32_t)outlen - BLAKE2B_OUTBYTES / 2;
 
         while (toproduce > BLAKE2B_OUTBYTES) {
             memcpy(in_buffer, out_buffer, BLAKE2B_OUTBYTES);
-            TRY(blake2b(out_buffer, BLAKE2B_OUTBYTES, in_buffer,
+            TRY(_cryptonite_blake2b(out_buffer, BLAKE2B_OUTBYTES, in_buffer,
                         BLAKE2B_OUTBYTES, NULL, 0));
             memcpy(out, out_buffer, BLAKE2B_OUTBYTES / 2);
             out += BLAKE2B_OUTBYTES / 2;
@@ -109,7 +109,7 @@ static int blake2b_long(void *pout, size_t outlen, const void *in, size_t inlen)
         }
 
         memcpy(in_buffer, out_buffer, BLAKE2B_OUTBYTES);
-        TRY(blake2b(out_buffer, toproduce, in_buffer, BLAKE2B_OUTBYTES, NULL,
+        TRY(_cryptonite_blake2b(out_buffer, toproduce, in_buffer, BLAKE2B_OUTBYTES, NULL,
                     0));
         memcpy(out, out_buffer, toproduce);
     }
@@ -149,7 +149,7 @@ static void store_block(void *output, const block *src) {
 }
 
 /***************Memory functions*****************/
-static 
+static
 int allocate_memory(const argon2_context *context, uint8_t **memory,
                     size_t num, size_t size) {
     size_t memory_size = num*size;
@@ -175,7 +175,7 @@ int allocate_memory(const argon2_context *context, uint8_t **memory,
 
     return ARGON2_OK;
 }
-static 
+static
 void free_memory(const argon2_context *context, uint8_t *memory,
                  size_t num, size_t size) {
     size_t memory_size = num*size;
@@ -425,7 +425,7 @@ fail:
 }
 
 #endif /* ARGON2_NO_THREADS */
-static 
+static
 int fill_memory_blocks(argon2_instance_t *instance) {
 	if (instance == NULL || instance->lanes == 0) {
 	    return ARGON2_INCORRECT_PARAMETER;
@@ -437,7 +437,7 @@ int fill_memory_blocks(argon2_instance_t *instance) {
 			fill_memory_blocks_st(instance) : fill_memory_blocks_mt(instance);
 #endif
 }
-static 
+static
 int validate_inputs(const argon2_context *context) {
     if (NULL == context) {
         return ARGON2_INCORRECT_PARAMETER;
@@ -564,7 +564,7 @@ int validate_inputs(const argon2_context *context) {
 
     return ARGON2_OK;
 }
-static 
+static
 void fill_first_blocks(uint8_t *blockhash, const argon2_instance_t *instance) {
     uint32_t l;
     /* Make the first and second block in each lane as G(H0||i||0) or
@@ -587,7 +587,7 @@ void fill_first_blocks(uint8_t *blockhash, const argon2_instance_t *instance) {
     }
     clear_internal_memory(blockhash_bytes, ARGON2_BLOCK_SIZE);
 }
-static 
+static
 void initial_hash(uint8_t *blockhash, argon2_context *context,
                   argon2_type type) {
     blake2b_state BlakeHash;
@@ -597,31 +597,31 @@ void initial_hash(uint8_t *blockhash, argon2_context *context,
         return;
     }
 
-    blake2b_init(&BlakeHash, ARGON2_PREHASH_DIGEST_LENGTH);
+    _cryptonite_blake2b_init(&BlakeHash, ARGON2_PREHASH_DIGEST_LENGTH);
 
     store32(&value, context->lanes);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     store32(&value, context->outlen);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     store32(&value, context->m_cost);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     store32(&value, context->t_cost);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     store32(&value, context->version);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     store32(&value, (uint32_t)type);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     store32(&value, context->pwdlen);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     if (context->pwd != NULL) {
-        blake2b_update(&BlakeHash, (const uint8_t *)context->pwd,
+        _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)context->pwd,
                        context->pwdlen);
 
         if (context->flags & ARGON2_FLAG_CLEAR_PASSWORD) {
@@ -631,18 +631,18 @@ void initial_hash(uint8_t *blockhash, argon2_context *context,
     }
 
     store32(&value, context->saltlen);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     if (context->salt != NULL) {
-        blake2b_update(&BlakeHash, (const uint8_t *)context->salt,
+        _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)context->salt,
                        context->saltlen);
     }
 
     store32(&value, context->secretlen);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     if (context->secret != NULL) {
-        blake2b_update(&BlakeHash, (const uint8_t *)context->secret,
+        _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)context->secret,
                        context->secretlen);
 
         if (context->flags & ARGON2_FLAG_CLEAR_SECRET) {
@@ -652,16 +652,16 @@ void initial_hash(uint8_t *blockhash, argon2_context *context,
     }
 
     store32(&value, context->adlen);
-    blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
+    _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)&value, sizeof(value));
 
     if (context->ad != NULL) {
-        blake2b_update(&BlakeHash, (const uint8_t *)context->ad,
+        _cryptonite_blake2b_update(&BlakeHash, (const uint8_t *)context->ad,
                        context->adlen);
     }
 
-    blake2b_final(&BlakeHash, blockhash, ARGON2_PREHASH_DIGEST_LENGTH);
+    _cryptonite_blake2b_final(&BlakeHash, blockhash, ARGON2_PREHASH_DIGEST_LENGTH);
 }
-static 
+static
 int initialize(argon2_instance_t *instance, argon2_context *context) {
     uint8_t blockhash[ARGON2_PREHASH_SEED_LENGTH];
     int result = ARGON2_OK;

--- a/cbits/blake2/ref/blake2.h
+++ b/cbits/blake2/ref/blake2.h
@@ -142,51 +142,51 @@ extern "C" {
   };
 
   /* Streaming API */
-  int blake2s_init( blake2s_state *S, size_t outlen );
-  int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2s_init_param( blake2s_state *S, const blake2s_param *P );
-  int blake2s_update( blake2s_state *S, const void *in, size_t inlen );
-  int blake2s_final( blake2s_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2s_init( blake2s_state *S, size_t outlen );
+  int _cryptonite_blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2s_init_param( blake2s_state *S, const blake2s_param *P );
+  int _cryptonite_blake2s_update( blake2s_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2s_final( blake2s_state *S, void *out, size_t outlen );
 
-  int blake2b_init( blake2b_state *S, size_t outlen );
-  int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2b_init_param( blake2b_state *S, const blake2b_param *P );
-  int blake2b_update( blake2b_state *S, const void *in, size_t inlen );
-  int blake2b_final( blake2b_state *S, void *out, size_t outlen );
+  int _cryptonite__cryptonite_blake2b_init( blake2b_state *S, size_t outlen );
+  int _cryptonite_blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2b_init_param( blake2b_state *S, const blake2b_param *P );
+  int _cryptonite_blake2b_update( blake2b_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2b_final( blake2b_state *S, void *out, size_t outlen );
 
-  int blake2sp_init( blake2sp_state *S, size_t outlen );
-  int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2sp_update( blake2sp_state *S, const void *in, size_t inlen );
-  int blake2sp_final( blake2sp_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2sp_init( blake2sp_state *S, size_t outlen );
+  int _cryptonite_blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2sp_update( blake2sp_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2sp_final( blake2sp_state *S, void *out, size_t outlen );
 
-  int blake2bp_init( blake2bp_state *S, size_t outlen );
-  int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2bp_update( blake2bp_state *S, const void *in, size_t inlen );
-  int blake2bp_final( blake2bp_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2bp_init( blake2bp_state *S, size_t outlen );
+  int _cryptonite_blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2bp_update( blake2bp_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2bp_final( blake2bp_state *S, void *out, size_t outlen );
 
   /* Variable output length API */
-  int blake2xs_init( blake2xs_state *S, const size_t outlen );
-  int blake2xs_init_key( blake2xs_state *S, const size_t outlen, const void *key, size_t keylen );
-  int blake2xs_update( blake2xs_state *S, const void *in, size_t inlen );
-  int blake2xs_final(blake2xs_state *S, void *out, size_t outlen);
+  int _cryptonite_blake2xs_init( blake2xs_state *S, const size_t outlen );
+  int _cryptonite_blake2xs_init_key( blake2xs_state *S, const size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xs_update( blake2xs_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2xs_final(blake2xs_state *S, void *out, size_t outlen);
 
-  int blake2xb_init( blake2xb_state *S, const size_t outlen );
-  int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen );
-  int blake2xb_update( blake2xb_state *S, const void *in, size_t inlen );
-  int blake2xb_final(blake2xb_state *S, void *out, size_t outlen);
+  int _cryptonite_blake2xb_init( blake2xb_state *S, const size_t outlen );
+  int _cryptonite_blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xb_update( blake2xb_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2xb_final(blake2xb_state *S, void *out, size_t outlen);
 
   /* Simple API */
-  int blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
-  int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
-  int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
-  int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
-  int blake2xs( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
-  int blake2xb( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xs( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xb( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
   /* This is simply an alias for blake2b */
-  int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
 #if defined(__cplusplus)
 }

--- a/cbits/blake2/ref/blake2.h
+++ b/cbits/blake2/ref/blake2.h
@@ -148,7 +148,7 @@ extern "C" {
   int _cryptonite_blake2s_update( blake2s_state *S, const void *in, size_t inlen );
   int _cryptonite_blake2s_final( blake2s_state *S, void *out, size_t outlen );
 
-  int _cryptonite__cryptonite_blake2b_init( blake2b_state *S, size_t outlen );
+  int _cryptonite_blake2b_init( blake2b_state *S, size_t outlen );
   int _cryptonite_blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
   int _cryptonite_blake2b_init_param( blake2b_state *S, const blake2b_param *P );
   int _cryptonite_blake2b_update( blake2b_state *S, const void *in, size_t inlen );

--- a/cbits/blake2/ref/blake2b-ref.c
+++ b/cbits/blake2/ref/blake2b-ref.c
@@ -99,7 +99,7 @@ int _cryptonite_blake2b_init( blake2b_state *S, size_t outlen )
 {
   blake2b_param P[1];
 
-  if ( ( !outlen ) || ( outlen > blake2B_OUTBYTES ) ) return -1;
+  if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
 
   P->digest_length = (uint8_t)outlen;
   P->key_length    = 0;

--- a/cbits/blake2/ref/blake2b-ref.c
+++ b/cbits/blake2/ref/blake2b-ref.c
@@ -45,31 +45,31 @@ static const uint8_t blake2b_sigma[12][16] =
 };
 
 
-static void _cryptonite_blake2b_set_lastnode( blake2b_state *S )
+static void blake2b_set_lastnode( blake2b_state *S )
 {
   S->f[1] = (uint64_t)-1;
 }
 
 /* Some helper functions, not necessarily useful */
-static int _cryptonite_blake2b_is_lastblock( const blake2b_state *S )
+static int blake2b_is_lastblock( const blake2b_state *S )
 {
   return S->f[0] != 0;
 }
 
-static void _cryptonite_blake2b_set_lastblock( blake2b_state *S )
+static void blake2b_set_lastblock( blake2b_state *S )
 {
-  if( S->last_node ) _cryptonite_blake2b_set_lastnode( S );
+  if( S->last_node ) blake2b_set_lastnode( S );
 
   S->f[0] = (uint64_t)-1;
 }
 
-static void _cryptonite_blake2b_increment_counter( blake2b_state *S, const uint64_t inc )
+static void blake2b_increment_counter( blake2b_state *S, const uint64_t inc )
 {
   S->t[0] += inc;
   S->t[1] += ( S->t[0] < inc );
 }
 
-static void _cryptonite_blake2b_init0( blake2b_state *S )
+static void blake2b_init0( blake2b_state *S )
 {
   size_t i;
   memset( S, 0, sizeof( blake2b_state ) );
@@ -83,7 +83,7 @@ int _cryptonite_blake2b_init_param( blake2b_state *S, const blake2b_param *P )
   const uint8_t *p = ( const uint8_t * )( P );
   size_t i;
 
-  _cryptonite_blake2b_init0( S );
+  blake2b_init0( S );
 
   /* IV XOR ParamBlock */
   for( i = 0; i < 8; ++i )
@@ -174,7 +174,7 @@ int _cryptonite_blake2b_init_key( blake2b_state *S, size_t outlen, const void *k
     G(r,7,v[ 3],v[ 4],v[ 9],v[14]); \
   } while(0)
 
-static void _cryptonite_blake2b_compress( blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES] )
+static void blake2b_compress( blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES] )
 {
   uint64_t m[16];
   uint64_t v[16];
@@ -229,12 +229,12 @@ int _cryptonite_blake2b_update( blake2b_state *S, const void *pin, size_t inlen 
     {
       S->buflen = 0;
       memcpy( S->buf + left, in, fill ); /* Fill buffer */
-      _cryptonite_blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
-      _cryptonite_blake2b_compress( S, S->buf ); /* Compress */
+      blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
+      blake2b_compress( S, S->buf ); /* Compress */
       in += fill; inlen -= fill;
       while(inlen > BLAKE2B_BLOCKBYTES) {
-        _cryptonite_blake2b_increment_counter(S, BLAKE2B_BLOCKBYTES);
-        _cryptonite_blake2b_compress( S, in );
+        blake2b_increment_counter(S, BLAKE2B_BLOCKBYTES);
+        blake2b_compress( S, in );
         in += BLAKE2B_BLOCKBYTES;
         inlen -= BLAKE2B_BLOCKBYTES;
       }
@@ -253,13 +253,13 @@ int _cryptonite_blake2b_final( blake2b_state *S, void *out, size_t outlen )
   if( out == NULL || outlen < S->outlen )
     return -1;
 
-  if( _cryptonite_blake2b_is_lastblock( S ) )
+  if( blake2b_is_lastblock( S ) )
     return -1;
 
-  _cryptonite_blake2b_increment_counter( S, S->buflen );
-  _cryptonite_blake2b_set_lastblock( S );
+  blake2b_increment_counter( S, S->buflen );
+  blake2b_set_lastblock( S );
   memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
-  _cryptonite_blake2b_compress( S, S->buf );
+  blake2b_compress( S, S->buf );
 
   for( i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
     store64( buffer + sizeof( S->h[i] ) * i, S->h[i] );

--- a/cbits/blake2/ref/blake2bp-ref.c
+++ b/cbits/blake2/ref/blake2bp-ref.c
@@ -78,7 +78,7 @@ static int blake2bp_init_root( blake2b_state *S, size_t outlen, size_t keylen )
 }
 
 
-int blake2bp_init( blake2bp_state *S, size_t outlen )
+int _cryptonite_blake2bp_init( blake2bp_state *S, size_t outlen )
 {
   size_t i;
 
@@ -99,7 +99,7 @@ int blake2bp_init( blake2bp_state *S, size_t outlen )
   return 0;
 }
 
-int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen )
+int _cryptonite_blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen )
 {
   size_t i;
 
@@ -125,7 +125,7 @@ int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2b_update( S->S[i], block, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S->S[i], block, BLAKE2B_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -133,7 +133,7 @@ int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t
 }
 
 
-int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   size_t left = S->buflen;
@@ -145,7 +145,7 @@ int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
     memcpy( S->buf + left, in, fill );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES );
 
     in += fill;
     inlen -= fill;
@@ -168,7 +168,7 @@ int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES )
     {
-      blake2b_update( S->S[i], in__, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S->S[i], in__, BLAKE2B_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
     }
@@ -184,7 +184,7 @@ int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
   return 0;
 }
 
-int blake2bp_final( blake2bp_state *S, void *out, size_t outlen )
+int _cryptonite_blake2bp_final( blake2bp_state *S, void *out, size_t outlen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2B_OUTBYTES];
   size_t i;
@@ -201,19 +201,19 @@ int blake2bp_final( blake2bp_state *S, void *out, size_t outlen )
 
       if( left > BLAKE2B_BLOCKBYTES ) left = BLAKE2B_BLOCKBYTES;
 
-      blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, left );
+      _cryptonite_blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, left );
     }
 
-    blake2b_final( S->S[i], hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_final( S->S[i], hash[i], BLAKE2B_OUTBYTES );
   }
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2b_update( S->R, hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_update( S->R, hash[i], BLAKE2B_OUTBYTES );
 
-  return blake2b_final( S->R, out, S->outlen );
+  return _cryptonite_blake2b_final( S->R, out, S->outlen );
 }
 
-int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+int _cryptonite_blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2B_OUTBYTES];
   blake2b_state S[PARALLELISM_DEGREE][1];
@@ -243,7 +243,7 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2b_update( S[i], block, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S[i], block, BLAKE2B_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -264,7 +264,7 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES )
     {
-      blake2b_update( S[i], in__, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S[i], in__, BLAKE2B_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
     }
@@ -273,10 +273,10 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
     {
       const size_t left = inlen__ - i * BLAKE2B_BLOCKBYTES;
       const size_t len = left <= BLAKE2B_BLOCKBYTES ? left : BLAKE2B_BLOCKBYTES;
-      blake2b_update( S[i], in__, len );
+      _cryptonite_blake2b_update( S[i], in__, len );
     }
 
-    blake2b_final( S[i], hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_final( S[i], hash[i], BLAKE2B_OUTBYTES );
   }
 
   if( blake2bp_init_root( FS, outlen, keylen ) < 0 )
@@ -285,9 +285,9 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
   FS->last_node = 1; /* Mark as last node */
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2b_update( FS, hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_update( FS, hash[i], BLAKE2B_OUTBYTES );
 
-  return blake2b_final( FS, out, outlen );;
+  return _cryptonite_blake2b_final( FS, out, outlen );;
 }
 
 #if defined(BLAKE2BP_SELFTEST)
@@ -326,21 +326,21 @@ int main( void )
       size_t mlen = i;
       int err = 0;
 
-      if( (err = blake2bp_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2bp_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2bp_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2bp_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2bp_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2bp_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2bp_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
+      if ( (err = _cryptonite_blake2bp_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/ref/blake2s-ref.c
+++ b/cbits/blake2/ref/blake2s-ref.c
@@ -73,7 +73,7 @@ static void blake2s_init0( blake2s_state *S )
 }
 
 /* init2 xors IV with input parameter block */
-int blake2s_init_param( blake2s_state *S, const blake2s_param *P )
+int _cryptonite_blake2s_init_param( blake2s_state *S, const blake2s_param *P )
 {
   const unsigned char *p = ( const unsigned char * )( P );
   size_t i;
@@ -90,7 +90,7 @@ int blake2s_init_param( blake2s_state *S, const blake2s_param *P )
 
 
 /* Sequential blake2s initialization */
-int blake2s_init( blake2s_state *S, size_t outlen )
+int _cryptonite_blake2s_init( blake2s_state *S, size_t outlen )
 {
   blake2s_param P[1];
 
@@ -109,10 +109,10 @@ int blake2s_init( blake2s_state *S, size_t outlen )
   /* memset(P->reserved, 0, sizeof(P->reserved) ); */
   memset( P->salt,     0, sizeof( P->salt ) );
   memset( P->personal, 0, sizeof( P->personal ) );
-  return blake2s_init_param( S, P );
+  return _cryptonite_blake2s_init_param( S, P );
 }
 
-int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen )
+int _cryptonite_blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen )
 {
   blake2s_param P[1];
 
@@ -133,13 +133,13 @@ int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t k
   memset( P->salt,     0, sizeof( P->salt ) );
   memset( P->personal, 0, sizeof( P->personal ) );
 
-  if( blake2s_init_param( S, P ) < 0 ) return -1;
+  if( _cryptonite_blake2s_init_param( S, P ) < 0 ) return -1;
 
   {
     uint8_t block[BLAKE2S_BLOCKBYTES];
     memset( block, 0, BLAKE2S_BLOCKBYTES );
     memcpy( block, key, keylen );
-    blake2s_update( S, block, BLAKE2S_BLOCKBYTES );
+    _cryptonite_blake2s_update( S, block, BLAKE2S_BLOCKBYTES );
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from stack */
   }
   return 0;
@@ -211,7 +211,7 @@ static void blake2s_compress( blake2s_state *S, const uint8_t in[BLAKE2S_BLOCKBY
 #undef G
 #undef ROUND
 
-int blake2s_update( blake2s_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2s_update( blake2s_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   if( inlen > 0 )
@@ -238,7 +238,7 @@ int blake2s_update( blake2s_state *S, const void *pin, size_t inlen )
   return 0;
 }
 
-int blake2s_final( blake2s_state *S, void *out, size_t outlen )
+int _cryptonite_blake2s_final( blake2s_state *S, void *out, size_t outlen )
 {
   uint8_t buffer[BLAKE2S_OUTBYTES] = {0};
   size_t i;
@@ -262,7 +262,7 @@ int blake2s_final( blake2s_state *S, void *out, size_t outlen )
   return 0;
 }
 
-int blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+int _cryptonite_blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
 {
   blake2s_state S[1];
 
@@ -279,22 +279,22 @@ int blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void 
 
   if( keylen > 0 )
   {
-    if( blake2s_init_key( S, outlen, key, keylen ) < 0 ) return -1;
+    if( _cryptonite_blake2s_init_key( S, outlen, key, keylen ) < 0 ) return -1;
   }
   else
   {
-    if( blake2s_init( S, outlen ) < 0 ) return -1;
+    if( _cryptonite_blake2s_init( S, outlen ) < 0 ) return -1;
   }
 
-  blake2s_update( S, ( const uint8_t * )in, inlen );
-  blake2s_final( S, out, outlen );
+  _cryptonite_blake2s_update( S, ( const uint8_t * )in, inlen );
+  _cryptonite_blake2s_final( S, out, outlen );
   return 0;
 }
 
 #if defined(SUPERCOP)
 int crypto_hash( unsigned char *out, unsigned char *in, unsigned long long inlen )
 {
-  return blake2s( out, BLAKE2S_OUTBYTES, in, inlen, NULL, 0 );
+  return _cryptonite_blake2s( out, BLAKE2S_OUTBYTES, in, inlen, NULL, 0 );
 }
 #endif
 
@@ -317,7 +317,7 @@ int main( void )
   for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
   {
     uint8_t hash[BLAKE2S_OUTBYTES];
-    blake2s( hash, BLAKE2S_OUTBYTES, buf, i, key, BLAKE2S_KEYBYTES );
+    _cryptonite_blake2s( hash, BLAKE2S_OUTBYTES, buf, i, key, BLAKE2S_KEYBYTES );
 
     if( 0 != memcmp( hash, blake2s_keyed_kat[i], BLAKE2S_OUTBYTES ) )
     {
@@ -334,21 +334,21 @@ int main( void )
       size_t mlen = i;
       int err = 0;
 
-      if( (err = blake2s_init_key(&S, BLAKE2S_OUTBYTES, key, BLAKE2S_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2s_init_key(&S, BLAKE2S_OUTBYTES, key, BLAKE2S_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2s_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2s_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2s_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2s_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2s_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {
+      if ( (err = _cryptonite_blake2s_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/ref/blake2sp-ref.c
+++ b/cbits/blake2/ref/blake2sp-ref.c
@@ -75,7 +75,7 @@ static int blake2sp_init_root( blake2s_state *S, size_t outlen, size_t keylen )
 }
 
 
-int blake2sp_init( blake2sp_state *S, size_t outlen )
+int _cryptonite_blake2sp_init( blake2sp_state *S, size_t outlen )
 {
   size_t i;
 
@@ -96,7 +96,7 @@ int blake2sp_init( blake2sp_state *S, size_t outlen )
   return 0;
 }
 
-int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen )
+int _cryptonite_blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen )
 {
   size_t i;
 
@@ -122,7 +122,7 @@ int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2s_update( S->S[i], block, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S->S[i], block, BLAKE2S_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -130,7 +130,7 @@ int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t
 }
 
 
-int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   size_t left = S->buflen;
@@ -142,7 +142,7 @@ int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
     memcpy( S->buf + left, in, fill );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, BLAKE2S_BLOCKBYTES );
 
     in += fill;
     inlen -= fill;
@@ -164,7 +164,7 @@ int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES )
     {
-      blake2s_update( S->S[i], in__, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S->S[i], in__, BLAKE2S_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
     }
@@ -181,7 +181,7 @@ int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
 }
 
 
-int blake2sp_final( blake2sp_state *S, void *out, size_t outlen )
+int _cryptonite_blake2sp_final( blake2sp_state *S, void *out, size_t outlen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2S_OUTBYTES];
   size_t i;
@@ -198,20 +198,20 @@ int blake2sp_final( blake2sp_state *S, void *out, size_t outlen )
 
       if( left > BLAKE2S_BLOCKBYTES ) left = BLAKE2S_BLOCKBYTES;
 
-      blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, left );
+      _cryptonite_blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, left );
     }
 
-    blake2s_final( S->S[i], hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_final( S->S[i], hash[i], BLAKE2S_OUTBYTES );
   }
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2s_update( S->R, hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_update( S->R, hash[i], BLAKE2S_OUTBYTES );
 
-  return blake2s_final( S->R, out, S->outlen );
+  return _cryptonite_blake2s_final( S->R, out, S->outlen );
 }
 
 
-int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+int _cryptonite_blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2S_OUTBYTES];
   blake2s_state S[PARALLELISM_DEGREE][1];
@@ -241,7 +241,7 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2s_update( S[i], block, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S[i], block, BLAKE2S_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -262,7 +262,7 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES )
     {
-      blake2s_update( S[i], in__, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S[i], in__, BLAKE2S_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
     }
@@ -271,10 +271,10 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
     {
       const size_t left = inlen__ - i * BLAKE2S_BLOCKBYTES;
       const size_t len = left <= BLAKE2S_BLOCKBYTES ? left : BLAKE2S_BLOCKBYTES;
-      blake2s_update( S[i], in__, len );
+      _cryptonite_blake2s_update( S[i], in__, len );
     }
 
-    blake2s_final( S[i], hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_final( S[i], hash[i], BLAKE2S_OUTBYTES );
   }
 
   if( blake2sp_init_root( FS, outlen, keylen ) < 0 )
@@ -283,9 +283,9 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
   FS->last_node = 1;
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2s_update( FS, hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_update( FS, hash[i], BLAKE2S_OUTBYTES );
 
-  return blake2s_final( FS, out, outlen );
+  return _cryptonite_blake2s_final( FS, out, outlen );
 }
 
 
@@ -309,7 +309,7 @@ int main( void )
   for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
   {
     uint8_t hash[BLAKE2S_OUTBYTES];
-    blake2sp( hash, BLAKE2S_OUTBYTES, buf, i, key, BLAKE2S_KEYBYTES );
+    _cryptonite_blake2sp( hash, BLAKE2S_OUTBYTES, buf, i, key, BLAKE2S_KEYBYTES );
 
     if( 0 != memcmp( hash, blake2sp_keyed_kat[i], BLAKE2S_OUTBYTES ) )
     {
@@ -326,21 +326,21 @@ int main( void )
       size_t mlen = i;
       int err = 0;
 
-      if( (err = blake2sp_init_key(&S, BLAKE2S_OUTBYTES, key, BLAKE2S_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2sp_init_key(&S, BLAKE2S_OUTBYTES, key, BLAKE2S_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2sp_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2sp_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2sp_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2sp_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2sp_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {
+      if ( (err = _cryptonite_blake2sp_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/ref/blake2xb-ref.c
+++ b/cbits/blake2/ref/blake2xb-ref.c
@@ -23,11 +23,11 @@
 #include "blake2.h"
 #include "blake2-impl.h"
 
-int blake2xb_init( blake2xb_state *S, const size_t outlen ) {
-  return blake2xb_init_key(S, outlen, NULL, 0);
+int _cryptonite_blake2xb_init( blake2xb_state *S, const size_t outlen ) {
+  return _cryptonite_blake2xb_init_key(S, outlen, NULL, 0);
 }
 
-int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen)
+int _cryptonite_blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen)
 {
   if ( outlen == 0 || outlen > 0xFFFFFFFFUL ) {
     return -1;
@@ -55,7 +55,7 @@ int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, 
   memset( S->P->salt,     0, sizeof( S->P->salt ) );
   memset( S->P->personal, 0, sizeof( S->P->personal ) );
 
-  if( blake2b_init_param( S->S, S->P ) < 0 ) {
+  if( _cryptonite_blake2b_init_param( S->S, S->P ) < 0 ) {
     return -1;
   }
 
@@ -63,17 +63,17 @@ int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, 
     uint8_t block[BLAKE2B_BLOCKBYTES];
     memset(block, 0, BLAKE2B_BLOCKBYTES);
     memcpy(block, key, keylen);
-    blake2b_update(S->S, block, BLAKE2B_BLOCKBYTES);
+    _cryptonite_blake2b_update(S->S, block, BLAKE2B_BLOCKBYTES);
     secure_zero_memory(block, BLAKE2B_BLOCKBYTES);
   }
   return 0;
 }
 
-int blake2xb_update( blake2xb_state *S, const void *in, size_t inlen ) {
-    return blake2b_update( S->S, in, inlen );
+int _cryptonite_blake2xb_update( blake2xb_state *S, const void *in, size_t inlen ) {
+    return _cryptonite_blake2b_update( S->S, in, inlen );
 }
 
-int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
+int _cryptonite_blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
 
   blake2b_state C[1];
   blake2b_param P[1];
@@ -98,7 +98,7 @@ int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
   }
 
   /* Finalize the root hash */
-  if (blake2b_final(S->S, root, BLAKE2B_OUTBYTES) < 0) {
+  if (_cryptonite_blake2b_final(S->S, root, BLAKE2B_OUTBYTES) < 0) {
     return -1;
   }
 
@@ -117,10 +117,10 @@ int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
     /* Initialize state */
     P->digest_length = block_size;
     store32(&P->node_offset, i);
-    blake2b_init_param(C, P);
+    _cryptonite_blake2b_init_param(C, P);
     /* Process key if needed */
-    blake2b_update(C, root, BLAKE2B_OUTBYTES);
-    if (blake2b_final(C, (uint8_t *)out + i * BLAKE2B_OUTBYTES, block_size) < 0 ) {
+    _cryptonite_blake2b_update(C, root, BLAKE2B_OUTBYTES);
+    if (_cryptonite_blake2b_final(C, (uint8_t *)out + i * BLAKE2B_OUTBYTES, block_size) < 0 ) {
         return -1;
     }
     outlen -= block_size;
@@ -133,7 +133,7 @@ int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
 
 }
 
-int blake2xb(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen)
+int _cryptonite_blake2xb(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen)
 {
   blake2xb_state S[1];
 
@@ -154,15 +154,15 @@ int blake2xb(void *out, size_t outlen, const void *in, size_t inlen, const void 
     return -1;
 
   /* Initialize the root block structure */
-  if (blake2xb_init_key(S, outlen, key, keylen) < 0) {
+  if (_cryptonite_blake2xb_init_key(S, outlen, key, keylen) < 0) {
     return -1;
   }
 
   /* Absorb the input message */
-  blake2xb_update(S, in, inlen);
+  _cryptonite_blake2xb_update(S, in, inlen);
 
   /* Compute the root node of the tree and the final hash using the counter construction */
-  return blake2xb_final(S, out, outlen);
+  return _cryptonite_blake2xb_final(S, out, outlen);
 }
 
 #if defined(BLAKE2XB_SELFTEST)
@@ -189,7 +189,7 @@ int main( void )
   for( outlen = 1; outlen <= BLAKE2_KAT_LENGTH; ++outlen )
   {
       uint8_t hash[BLAKE2_KAT_LENGTH] = {0};
-      if( blake2xb( hash, outlen, buf, BLAKE2_KAT_LENGTH, key, BLAKE2B_KEYBYTES ) < 0 ) {
+      if( _cryptonite_blake2xb( hash, outlen, buf, BLAKE2_KAT_LENGTH, key, BLAKE2B_KEYBYTES ) < 0 ) {
         goto fail;
       }
 
@@ -208,21 +208,21 @@ int main( void )
       size_t mlen = BLAKE2_KAT_LENGTH;
       int err = 0;
 
-      if( (err = blake2xb_init_key(&S, outlen, key, BLAKE2B_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2xb_init_key(&S, outlen, key, BLAKE2B_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2xb_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2xb_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2xb_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2xb_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2xb_final(&S, hash, outlen)) < 0) {
+      if ( (err = _cryptonite_blake2xb_final(&S, hash, outlen)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/sse/blake2.h
+++ b/cbits/blake2/sse/blake2.h
@@ -142,51 +142,51 @@ extern "C" {
   };
 
   /* Streaming API */
-  int blake2s_init( blake2s_state *S, size_t outlen );
-  int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2s_init_param( blake2s_state *S, const blake2s_param *P );
-  int blake2s_update( blake2s_state *S, const void *in, size_t inlen );
-  int blake2s_final( blake2s_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2s_init( blake2s_state *S, size_t outlen );
+  int _cryptonite_blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2s_init_param( blake2s_state *S, const blake2s_param *P );
+  int _cryptonite_blake2s_update( blake2s_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2s_final( blake2s_state *S, void *out, size_t outlen );
 
-  int blake2b_init( blake2b_state *S, size_t outlen );
-  int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2b_init_param( blake2b_state *S, const blake2b_param *P );
-  int blake2b_update( blake2b_state *S, const void *in, size_t inlen );
-  int blake2b_final( blake2b_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2b_init( blake2b_state *S, size_t outlen );
+  int _cryptonite_blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2b_init_param( blake2b_state *S, const blake2b_param *P );
+  int _cryptonite_blake2b_update( blake2b_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2b_final( blake2b_state *S, void *out, size_t outlen );
 
-  int blake2sp_init( blake2sp_state *S, size_t outlen );
-  int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2sp_update( blake2sp_state *S, const void *in, size_t inlen );
-  int blake2sp_final( blake2sp_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2sp_init( blake2sp_state *S, size_t outlen );
+  int _cryptonite_blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2sp_update( blake2sp_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2sp_final( blake2sp_state *S, void *out, size_t outlen );
 
-  int blake2bp_init( blake2bp_state *S, size_t outlen );
-  int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen );
-  int blake2bp_update( blake2bp_state *S, const void *in, size_t inlen );
-  int blake2bp_final( blake2bp_state *S, void *out, size_t outlen );
+  int _cryptonite_blake2bp_init( blake2bp_state *S, size_t outlen );
+  int _cryptonite_blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2bp_update( blake2bp_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2bp_final( blake2bp_state *S, void *out, size_t outlen );
 
   /* Variable output length API */
-  int blake2xs_init( blake2xs_state *S, const size_t outlen );
-  int blake2xs_init_key( blake2xs_state *S, const size_t outlen, const void *key, size_t keylen );
-  int blake2xs_update( blake2xs_state *S, const void *in, size_t inlen );
-  int blake2xs_final(blake2xs_state *S, void *out, size_t outlen);
+  int _cryptonite_blake2xs_init( blake2xs_state *S, const size_t outlen );
+  int _cryptonite_blake2xs_init_key( blake2xs_state *S, const size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xs_update( blake2xs_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2xs_final(blake2xs_state *S, void *out, size_t outlen);
 
-  int blake2xb_init( blake2xb_state *S, const size_t outlen );
-  int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen );
-  int blake2xb_update( blake2xb_state *S, const void *in, size_t inlen );
-  int blake2xb_final(blake2xb_state *S, void *out, size_t outlen);
+  int _cryptonite_blake2xb_init( blake2xb_state *S, const size_t outlen );
+  int _cryptonite_blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xb_update( blake2xb_state *S, const void *in, size_t inlen );
+  int _cryptonite_blake2xb_final(blake2xb_state *S, void *out, size_t outlen);
 
   /* Simple API */
-  int blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
-  int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
-  int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
-  int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
-  int blake2xs( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
-  int blake2xb( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xs( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2xb( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
   /* This is simply an alias for blake2b */
-  int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+  int _cryptonite_blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
 #if defined(__cplusplus)
 }

--- a/cbits/blake2/sse/blake2b.c
+++ b/cbits/blake2/sse/blake2b.c
@@ -142,7 +142,7 @@ int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t k
     uint8_t block[BLAKE2B_BLOCKBYTES];
     memset( block, 0, BLAKE2B_BLOCKBYTES );
     memcpy( block, key, keylen );
-    blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
+    _cryptonite_blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
     secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
   }
   return 0;

--- a/cbits/blake2/sse/blake2b.c
+++ b/cbits/blake2/sse/blake2b.c
@@ -74,7 +74,7 @@ static void blake2b_increment_counter( blake2b_state *S, const uint64_t inc )
 }
 
 /* init xors IV with input parameter block */
-int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
+int _cryptonite_blake2b_init_param( blake2b_state *S, const blake2b_param *P )
 {
   size_t i;
   /*blake2b_init0( S ); */
@@ -92,7 +92,7 @@ int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
 
 
 /* Some sort of default parameter block initialization, for sequential blake2b */
-int blake2b_init( blake2b_state *S, size_t outlen )
+int _cryptonite_blake2b_init( blake2b_state *S, size_t outlen )
 {
   blake2b_param P[1];
 
@@ -111,10 +111,10 @@ int blake2b_init( blake2b_state *S, size_t outlen )
   memset( P->salt,     0, sizeof( P->salt ) );
   memset( P->personal, 0, sizeof( P->personal ) );
 
-  return blake2b_init_param( S, P );
+  return _cryptonite_blake2b_init_param( S, P );
 }
 
-int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen )
+int _cryptonite_blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen )
 {
   blake2b_param P[1];
 
@@ -135,7 +135,7 @@ int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t k
   memset( P->salt,     0, sizeof( P->salt ) );
   memset( P->personal, 0, sizeof( P->personal ) );
 
-  if( blake2b_init_param( S, P ) < 0 )
+  if( _cryptonite_blake2b_init_param( S, P ) < 0 )
     return 0;
 
   {
@@ -218,7 +218,7 @@ static void blake2b_compress( blake2b_state *S, const uint8_t block[BLAKE2B_BLOC
 }
 
 
-int blake2b_update( blake2b_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2b_update( blake2b_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   if( inlen > 0 )
@@ -246,7 +246,7 @@ int blake2b_update( blake2b_state *S, const void *pin, size_t inlen )
 }
 
 
-int blake2b_final( blake2b_state *S, void *out, size_t outlen )
+int _cryptonite_blake2b_final( blake2b_state *S, void *out, size_t outlen )
 {
   if( out == NULL || outlen < S->outlen )
     return -1;
@@ -264,7 +264,7 @@ int blake2b_final( blake2b_state *S, void *out, size_t outlen )
 }
 
 
-int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+int _cryptonite_blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
 {
   blake2b_state S[1];
 
@@ -281,26 +281,26 @@ int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void 
 
   if( keylen )
   {
-    if( blake2b_init_key( S, outlen, key, keylen ) < 0 ) return -1;
+    if( _cryptonite_blake2b_init_key( S, outlen, key, keylen ) < 0 ) return -1;
   }
   else
   {
-    if( blake2b_init( S, outlen ) < 0 ) return -1;
+    if( _cryptonite_blake2b_init( S, outlen ) < 0 ) return -1;
   }
 
-  blake2b_update( S, ( const uint8_t * )in, inlen );
-  blake2b_final( S, out, outlen );
+  _cryptonite_blake2b_update( S, ( const uint8_t * )in, inlen );
+  _cryptonite_blake2b_final( S, out, outlen );
   return 0;
 }
 
-int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen ) {
-  return blake2b(out, outlen, in, inlen, key, keylen);
+int _cryptonite_blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen ) {
+  return _cryptonite_blake2b(out, outlen, in, inlen, key, keylen);
 }
 
 #if defined(SUPERCOP)
 int crypto_hash( unsigned char *out, unsigned char *in, unsigned long long inlen )
 {
-  return blake2b( out, BLAKE2B_OUTBYTES, in, inlen, NULL, 0 );
+  return _cryptonite_blake2b( out, BLAKE2B_OUTBYTES, in, inlen, NULL, 0 );
 }
 #endif
 
@@ -340,21 +340,21 @@ int main( void )
       size_t mlen = i;
       int err = 0;
 
-      if( (err = blake2b_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2b_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2b_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2b_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2b_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2b_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2b_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
+      if ( (err = _cryptonite_blake2b_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/sse/blake2bp.c
+++ b/cbits/blake2/sse/blake2bp.c
@@ -36,7 +36,7 @@
 */
 static int blake2bp_init_leaf_param( blake2b_state *S, const blake2b_param *P )
 {
-  int err = blake2b_init_param(S, P);
+  int err = _cryptonite_blake2b_init_param(S, P);
   S->outlen = P->inner_length;
   return err;
 }
@@ -74,11 +74,11 @@ static int blake2bp_init_root( blake2b_state *S, size_t outlen, size_t keylen )
   memset( P->reserved, 0, sizeof( P->reserved ) );
   memset( P->salt, 0, sizeof( P->salt ) );
   memset( P->personal, 0, sizeof( P->personal ) );
-  return blake2b_init_param( S, P );
+  return _cryptonite_blake2b_init_param( S, P );
 }
 
 
-int blake2bp_init( blake2bp_state *S, size_t outlen )
+int _cryptonite_blake2bp_init( blake2bp_state *S, size_t outlen )
 {
   size_t i;
   if( !outlen || outlen > BLAKE2B_OUTBYTES ) return -1;
@@ -98,7 +98,7 @@ int blake2bp_init( blake2bp_state *S, size_t outlen )
   return 0;
 }
 
-int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen )
+int _cryptonite_blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t keylen )
 {
   size_t i;
 
@@ -124,7 +124,7 @@ int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2b_update( S->S[i], block, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S->S[i], block, BLAKE2B_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -132,7 +132,7 @@ int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t
 }
 
 
-int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   size_t left = S->buflen;
@@ -144,7 +144,7 @@ int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
     memcpy( S->buf + left, in, fill );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES );
 
     in += fill;
     inlen -= fill;
@@ -167,7 +167,7 @@ int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES )
     {
-      blake2b_update( S->S[i], in__, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S->S[i], in__, BLAKE2B_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
     }
@@ -185,7 +185,7 @@ int blake2bp_update( blake2bp_state *S, const void *pin, size_t inlen )
 
 
 
-int blake2bp_final( blake2bp_state *S, void *out, size_t outlen )
+int _cryptonite_blake2bp_final( blake2bp_state *S, void *out, size_t outlen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2B_OUTBYTES];
   size_t i;
@@ -202,19 +202,19 @@ int blake2bp_final( blake2bp_state *S, void *out, size_t outlen )
 
       if( left > BLAKE2B_BLOCKBYTES ) left = BLAKE2B_BLOCKBYTES;
 
-      blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, left );
+      _cryptonite_blake2b_update( S->S[i], S->buf + i * BLAKE2B_BLOCKBYTES, left );
     }
 
-    blake2b_final( S->S[i], hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_final( S->S[i], hash[i], BLAKE2B_OUTBYTES );
   }
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2b_update( S->R, hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_update( S->R, hash[i], BLAKE2B_OUTBYTES );
 
-  return blake2b_final( S->R, out, S->outlen );
+  return _cryptonite_blake2b_final( S->R, out, S->outlen );
 }
 
-int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+int _cryptonite_blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2B_OUTBYTES];
   blake2b_state S[PARALLELISM_DEGREE][1];
@@ -244,7 +244,7 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2b_update( S[i], block, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S[i], block, BLAKE2B_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -265,7 +265,7 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES )
     {
-      blake2b_update( S[i], in__, BLAKE2B_BLOCKBYTES );
+      _cryptonite_blake2b_update( S[i], in__, BLAKE2B_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2B_BLOCKBYTES;
     }
@@ -274,10 +274,10 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
     {
       const size_t left = inlen__ - i * BLAKE2B_BLOCKBYTES;
       const size_t len = left <= BLAKE2B_BLOCKBYTES ? left : BLAKE2B_BLOCKBYTES;
-      blake2b_update( S[i], in__, len );
+      _cryptonite_blake2b_update( S[i], in__, len );
     }
 
-    blake2b_final( S[i], hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_final( S[i], hash[i], BLAKE2B_OUTBYTES );
   }
 
   if( blake2bp_init_root( FS, outlen, keylen ) < 0 )
@@ -286,9 +286,9 @@ int blake2bp( void *out, size_t outlen, const void *in, size_t inlen, const void
   FS->last_node = 1; /* Mark as last node */
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2b_update( FS, hash[i], BLAKE2B_OUTBYTES );
+    _cryptonite_blake2b_update( FS, hash[i], BLAKE2B_OUTBYTES );
 
-  return blake2b_final( FS, out, outlen );
+  return _cryptonite_blake2b_final( FS, out, outlen );
 }
 
 
@@ -311,7 +311,7 @@ int main( void )
   for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
   {
     uint8_t hash[BLAKE2B_OUTBYTES];
-    blake2bp( hash, BLAKE2B_OUTBYTES, buf, i, key, BLAKE2B_KEYBYTES );
+    _cryptonite_blake2bp( hash, BLAKE2B_OUTBYTES, buf, i, key, BLAKE2B_KEYBYTES );
 
     if( 0 != memcmp( hash, blake2bp_keyed_kat[i], BLAKE2B_OUTBYTES ) )
     {
@@ -328,21 +328,21 @@ int main( void )
       size_t mlen = i;
       int err = 0;
 
-      if( (err = blake2bp_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2bp_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2bp_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2bp_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2bp_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2bp_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2bp_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
+      if ( (err = _cryptonite_blake2bp_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/sse/blake2s.c
+++ b/cbits/blake2/sse/blake2s.c
@@ -143,7 +143,7 @@ int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t k
     uint8_t block[BLAKE2S_BLOCKBYTES];
     memset( block, 0, BLAKE2S_BLOCKBYTES );
     memcpy( block, key, keylen );
-    blake2s_update( S, block, BLAKE2S_BLOCKBYTES );
+    _cryptonite_blake2s_update( S, block, BLAKE2S_BLOCKBYTES );
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from stack */
   }
   return 0;
@@ -206,7 +206,7 @@ static void blake2s_compress( blake2s_state *S, const uint8_t block[BLAKE2S_BLOC
   STOREU( &S->h[4], _mm_xor_si128( ff1, _mm_xor_si128( row2, row4 ) ) );
 }
 
-int blake2s_update( blake2s_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2s_update( blake2s_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   if( inlen > 0 )
@@ -282,7 +282,7 @@ int blake2s( void *out, size_t outlen, const void *in, size_t inlen, const void 
     if( blake2s_init( S, outlen ) < 0 ) return -1;
   }
 
-  blake2s_update( S, ( const uint8_t * )in, inlen );
+  _cryptonite_blake2s_update( S, ( const uint8_t * )in, inlen );
   blake2s_final( S, out, outlen );
   return 0;
 }
@@ -335,13 +335,13 @@ int main( void )
       }
 
       while (mlen >= step) {
-        if ( (err = blake2s_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2s_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2s_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2s_update(&S, p, mlen)) < 0) {
         goto fail;
       }
       if ( (err = blake2s_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {

--- a/cbits/blake2/sse/blake2sp.c
+++ b/cbits/blake2/sse/blake2sp.c
@@ -35,7 +35,7 @@
 */
 static int blake2sp_init_leaf_param( blake2s_state *S, const blake2s_param *P )
 {
-  int err = blake2s_init_param(S, P);
+  int err = _cryptonite_blake2s_init_param(S, P);
   S->outlen = P->inner_length;
   return err;
 }
@@ -71,11 +71,11 @@ static int blake2sp_init_root( blake2s_state *S, size_t outlen, size_t keylen )
   P->inner_length = BLAKE2S_OUTBYTES;
   memset( P->salt, 0, sizeof( P->salt ) );
   memset( P->personal, 0, sizeof( P->personal ) );
-  return blake2s_init_param( S, P );
+  return _cryptonite_blake2s_init_param( S, P );
 }
 
 
-int blake2sp_init( blake2sp_state *S, size_t outlen )
+int _cryptonite_blake2sp_init( blake2sp_state *S, size_t outlen )
 {
   size_t i;
 
@@ -96,7 +96,7 @@ int blake2sp_init( blake2sp_state *S, size_t outlen )
   return 0;
 }
 
-int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen )
+int _cryptonite_blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t keylen )
 {
   size_t i;
 
@@ -122,7 +122,7 @@ int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2s_update( S->S[i], block, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S->S[i], block, BLAKE2S_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -130,7 +130,7 @@ int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t
 }
 
 
-int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
+int _cryptonite_blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
 {
   const unsigned char * in = (const unsigned char *)pin;
   size_t left = S->buflen;
@@ -142,7 +142,7 @@ int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
     memcpy( S->buf + left, in, fill );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, BLAKE2S_BLOCKBYTES );
 
     in += fill;
     inlen -= fill;
@@ -165,7 +165,7 @@ int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES )
     {
-      blake2s_update( S->S[i], in__, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S->S[i], in__, BLAKE2S_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
     }
@@ -182,7 +182,7 @@ int blake2sp_update( blake2sp_state *S, const void *pin, size_t inlen )
 }
 
 
-int blake2sp_final( blake2sp_state *S, void *out, size_t outlen )
+int _cryptonite_blake2sp_final( blake2sp_state *S, void *out, size_t outlen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2S_OUTBYTES];
   size_t i;
@@ -199,20 +199,20 @@ int blake2sp_final( blake2sp_state *S, void *out, size_t outlen )
 
       if( left > BLAKE2S_BLOCKBYTES ) left = BLAKE2S_BLOCKBYTES;
 
-      blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, left );
+      _cryptonite_blake2s_update( S->S[i], S->buf + i * BLAKE2S_BLOCKBYTES, left );
     }
 
-    blake2s_final( S->S[i], hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_final( S->S[i], hash[i], BLAKE2S_OUTBYTES );
   }
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2s_update( S->R, hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_update( S->R, hash[i], BLAKE2S_OUTBYTES );
 
-  return blake2s_final( S->R, out, S->outlen );
+  return _cryptonite_blake2s_final( S->R, out, S->outlen );
 }
 
 
-int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+int _cryptonite_blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
 {
   uint8_t hash[PARALLELISM_DEGREE][BLAKE2S_OUTBYTES];
   blake2s_state S[PARALLELISM_DEGREE][1];
@@ -242,7 +242,7 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
     memcpy( block, key, keylen );
 
     for( i = 0; i < PARALLELISM_DEGREE; ++i )
-      blake2s_update( S[i], block, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S[i], block, BLAKE2S_BLOCKBYTES );
 
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from stack */
   }
@@ -263,7 +263,7 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
 
     while( inlen__ >= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES )
     {
-      blake2s_update( S[i], in__, BLAKE2S_BLOCKBYTES );
+      _cryptonite_blake2s_update( S[i], in__, BLAKE2S_BLOCKBYTES );
       in__ += PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
       inlen__ -= PARALLELISM_DEGREE * BLAKE2S_BLOCKBYTES;
     }
@@ -272,10 +272,10 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
     {
       const size_t left = inlen__ - i * BLAKE2S_BLOCKBYTES;
       const size_t len = left <= BLAKE2S_BLOCKBYTES ? left : BLAKE2S_BLOCKBYTES;
-      blake2s_update( S[i], in__, len );
+      _cryptonite_blake2s_update( S[i], in__, len );
     }
 
-    blake2s_final( S[i], hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_final( S[i], hash[i], BLAKE2S_OUTBYTES );
   }
 
   if( blake2sp_init_root( FS, outlen, keylen ) < 0 )
@@ -284,9 +284,9 @@ int blake2sp( void *out, size_t outlen, const void *in, size_t inlen, const void
   FS->last_node = 1;
 
   for( i = 0; i < PARALLELISM_DEGREE; ++i )
-    blake2s_update( FS, hash[i], BLAKE2S_OUTBYTES );
+    _cryptonite_blake2s_update( FS, hash[i], BLAKE2S_OUTBYTES );
 
-  return blake2s_final( FS, out, outlen );
+  return _cryptonite_blake2s_final( FS, out, outlen );
 }
 
 #if defined(BLAKE2SP_SELFTEST)
@@ -308,7 +308,7 @@ int main( void )
   for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
   {
     uint8_t hash[BLAKE2S_OUTBYTES];
-    blake2sp( hash, BLAKE2S_OUTBYTES, buf, i, key, BLAKE2S_KEYBYTES );
+    _cryptonite_blake2sp( hash, BLAKE2S_OUTBYTES, buf, i, key, BLAKE2S_KEYBYTES );
 
     if( 0 != memcmp( hash, blake2sp_keyed_kat[i], BLAKE2S_OUTBYTES ) )
     {
@@ -325,21 +325,21 @@ int main( void )
       size_t mlen = i;
       int err = 0;
 
-      if( (err = blake2sp_init_key(&S, BLAKE2S_OUTBYTES, key, BLAKE2S_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2sp_init_key(&S, BLAKE2S_OUTBYTES, key, BLAKE2S_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2sp_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2sp_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2sp_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2sp_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2sp_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {
+      if ( (err = _cryptonite_blake2sp_final(&S, hash, BLAKE2S_OUTBYTES)) < 0) {
         goto fail;
       }
 

--- a/cbits/blake2/sse/blake2xb.c
+++ b/cbits/blake2/sse/blake2xb.c
@@ -23,11 +23,11 @@
 #include "blake2.h"
 #include "blake2-impl.h"
 
-int blake2xb_init( blake2xb_state *S, const size_t outlen ) {
-  return blake2xb_init_key(S, outlen, NULL, 0);
+int _cryptonite_blake2xb_init( blake2xb_state *S, const size_t outlen ) {
+  return _cryptonite_blake2xb_init_key(S, outlen, NULL, 0);
 }
 
-int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen)
+int _cryptonite_blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, size_t keylen)
 {
   if ( outlen == 0 || outlen > 0xFFFFFFFFUL ) {
     return -1;
@@ -55,7 +55,7 @@ int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, 
   memset( S->P->salt,     0, sizeof( S->P->salt ) );
   memset( S->P->personal, 0, sizeof( S->P->personal ) );
 
-  if( blake2b_init_param( S->S, S->P ) < 0 ) {
+  if( _cryptonite_blake2b_init_param( S->S, S->P ) < 0 ) {
     return -1;
   }
 
@@ -63,17 +63,17 @@ int blake2xb_init_key( blake2xb_state *S, const size_t outlen, const void *key, 
     uint8_t block[BLAKE2B_BLOCKBYTES];
     memset(block, 0, BLAKE2B_BLOCKBYTES);
     memcpy(block, key, keylen);
-    blake2b_update(S->S, block, BLAKE2B_BLOCKBYTES);
+    _cryptonite_blake2b_update(S->S, block, BLAKE2B_BLOCKBYTES);
     secure_zero_memory(block, BLAKE2B_BLOCKBYTES);
   }
   return 0;
 }
 
-int blake2xb_update( blake2xb_state *S, const void *in, size_t inlen ) {
-    return blake2b_update( S->S, in, inlen );
+int _cryptonite_blake2xb_update( blake2xb_state *S, const void *in, size_t inlen ) {
+    return _cryptonite_blake2b_update( S->S, in, inlen );
 }
 
-int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
+int _cryptonite_blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
 
   blake2b_state C[1];
   blake2b_param P[1];
@@ -98,7 +98,7 @@ int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
   }
 
   /* Finalize the root hash */
-  if (blake2b_final(S->S, root, BLAKE2B_OUTBYTES) < 0) {
+  if (_cryptonite_blake2b_final(S->S, root, BLAKE2B_OUTBYTES) < 0) {
     return -1;
   }
 
@@ -117,10 +117,10 @@ int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
     /* Initialize state */
     P->digest_length = block_size;
     store32(&P->node_offset, i);
-    blake2b_init_param(C, P);
+    _cryptonite_blake2b_init_param(C, P);
     /* Process key if needed */
-    blake2b_update(C, root, BLAKE2B_OUTBYTES);
-    if (blake2b_final(C, (uint8_t *)out + i * BLAKE2B_OUTBYTES, block_size) < 0 ) {
+    _cryptonite_blake2b_update(C, root, BLAKE2B_OUTBYTES);
+    if (_cryptonite_blake2b_final(C, (uint8_t *)out + i * BLAKE2B_OUTBYTES, block_size) < 0 ) {
         return -1;
     }
     outlen -= block_size;
@@ -133,7 +133,7 @@ int blake2xb_final( blake2xb_state *S, void *out, size_t outlen) {
 
 }
 
-int blake2xb(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen)
+int _cryptonite_blake2xb(void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen)
 {
   blake2xb_state S[1];
 
@@ -154,15 +154,15 @@ int blake2xb(void *out, size_t outlen, const void *in, size_t inlen, const void 
     return -1;
 
   /* Initialize the root block structure */
-  if (blake2xb_init_key(S, outlen, key, keylen) < 0) {
+  if (_cryptonite_blake2xb_init_key(S, outlen, key, keylen) < 0) {
     return -1;
   }
 
   /* Absorb the input message */
-  blake2xb_update(S, in, inlen);
+  _cryptonite_blake2xb_update(S, in, inlen);
 
   /* Compute the root node of the tree and the final hash using the counter construction */
-  return blake2xb_final(S, out, outlen);
+  return _cryptonite_blake2xb_final(S, out, outlen);
 }
 
 #if defined(BLAKE2XB_SELFTEST)
@@ -189,7 +189,7 @@ int main( void )
   for( outlen = 1; outlen <= BLAKE2_KAT_LENGTH; ++outlen )
   {
       uint8_t hash[BLAKE2_KAT_LENGTH] = {0};
-      if( blake2xb( hash, outlen, buf, BLAKE2_KAT_LENGTH, key, BLAKE2B_KEYBYTES ) < 0 ) {
+      if( _cryptonite_blake2xb( hash, outlen, buf, BLAKE2_KAT_LENGTH, key, BLAKE2B_KEYBYTES ) < 0 ) {
         goto fail;
       }
 
@@ -208,21 +208,21 @@ int main( void )
       size_t mlen = BLAKE2_KAT_LENGTH;
       int err = 0;
 
-      if( (err = blake2xb_init_key(&S, outlen, key, BLAKE2B_KEYBYTES)) < 0 ) {
+      if( (err = _cryptonite_blake2xb_init_key(&S, outlen, key, BLAKE2B_KEYBYTES)) < 0 ) {
         goto fail;
       }
 
       while (mlen >= step) {
-        if ( (err = blake2xb_update(&S, p, step)) < 0 ) {
+        if ( (err = _cryptonite_blake2xb_update(&S, p, step)) < 0 ) {
           goto fail;
         }
         mlen -= step;
         p += step;
       }
-      if ( (err = blake2xb_update(&S, p, mlen)) < 0) {
+      if ( (err = _cryptonite_blake2xb_update(&S, p, mlen)) < 0) {
         goto fail;
       }
-      if ( (err = blake2xb_final(&S, hash, outlen)) < 0) {
+      if ( (err = _cryptonite_blake2xb_final(&S, hash, outlen)) < 0) {
         goto fail;
       }
 

--- a/cbits/cryptonite_blake2b.c
+++ b/cbits/cryptonite_blake2b.c
@@ -2,15 +2,15 @@
 
 void cryptonite_blake2b_init(blake2b_ctx *ctx, uint32_t hashlen)
 {
-	blake2b_init(ctx, hashlen / 8);
+	_cryptonite_blake2b_init(ctx, hashlen / 8);
 }
 
 void cryptonite_blake2b_update(blake2b_ctx *ctx, const uint8_t *data, uint32_t len)
 {
-	blake2b_update(ctx, data, len);
+	_cryptonite_blake2b_update(ctx, data, len);
 }
 
 void cryptonite_blake2b_finalize(blake2b_ctx *ctx, uint32_t hashlen, uint8_t *out)
 {
-	blake2b_final(ctx, out, hashlen / 8);
+	_cryptonite_blake2b_final(ctx, out, hashlen / 8);
 }

--- a/cbits/cryptonite_blake2bp.c
+++ b/cbits/cryptonite_blake2bp.c
@@ -2,15 +2,15 @@
 
 void cryptonite_blake2bp_init(blake2bp_ctx *ctx, uint32_t hashlen)
 {
-	blake2bp_init(ctx, hashlen / 8);
+	_cryptonite_blake2bp_init(ctx, hashlen / 8);
 }
 
 void cryptonite_blake2bp_update(blake2bp_ctx *ctx, const uint8_t *data, uint32_t len)
 {
-	blake2bp_update(ctx, data, len);
+	_cryptonite_blake2bp_update(ctx, data, len);
 }
 
 void cryptonite_blake2bp_finalize(blake2bp_ctx *ctx, uint32_t hashlen, uint8_t *out)
 {
-	blake2bp_final(ctx, out, hashlen / 8);
+	_cryptonite_blake2bp_final(ctx, out, hashlen / 8);
 }

--- a/cbits/cryptonite_blake2s.c
+++ b/cbits/cryptonite_blake2s.c
@@ -2,15 +2,15 @@
 
 void cryptonite_blake2s_init(blake2s_ctx *ctx, uint32_t hashlen)
 {
-	blake2s_init(ctx, hashlen / 8);
+	_cryptonite_blake2s_init(ctx, hashlen / 8);
 }
 
 void cryptonite_blake2s_update(blake2s_ctx *ctx, const uint8_t *data, uint32_t len)
 {
-	blake2s_update(ctx, data, len);
+	_cryptonite_blake2s_update(ctx, data, len);
 }
 
 void cryptonite_blake2s_finalize(blake2s_ctx *ctx, uint32_t hashlen, uint8_t *out)
 {
-	blake2s_final(ctx, out, hashlen / 8);
+	_cryptonite_blake2s_final(ctx, out, hashlen / 8);
 }

--- a/cbits/cryptonite_blake2sp.c
+++ b/cbits/cryptonite_blake2sp.c
@@ -2,15 +2,15 @@
 
 void cryptonite_blake2sp_init(blake2sp_ctx *ctx, uint32_t hashlen)
 {
-	blake2sp_init(ctx, hashlen / 8);
+	_cryptonite_blake2sp_init(ctx, hashlen / 8);
 }
 
 void cryptonite_blake2sp_update(blake2sp_ctx *ctx, const uint8_t *data, uint32_t len)
 {
-	blake2sp_update(ctx, data, len);
+	_cryptonite_blake2sp_update(ctx, data, len);
 }
 
 void cryptonite_blake2sp_finalize(blake2sp_ctx *ctx, uint32_t hashlen, uint8_t *out)
 {
-	blake2sp_final(ctx, out, hashlen / 8);
+	_cryptonite_blake2sp_final(ctx, out, hashlen / 8);
 }


### PR DESCRIPTION
Not all blake functions have the prefix, which results in linker errors. Just putting a `_cryptonite_` prefix to avoid such cases. Reason of choosing `_cryptonite_` over `cryptonite_` is because the exposed blake functions already have the `cryptonite_` prefix, which would be a bit of a mess (to have different functions with the same name). 