### PR TITLE
Remove UNROLL macro.

### DIFF
--- a/cbits/decaf/include/word.h
+++ b/cbits/decaf/include/word.h
@@ -235,17 +235,6 @@ malloc_vector(size_t size) {
     }
 }
 
-/* PERF: vectorize vs unroll */
-#ifdef __clang__
-#if 100*__clang_major__ + __clang_minor__ > 305
-#define UNROLL _Pragma("clang loop unroll(full)")
-#endif
-#endif
-
-#ifndef UNROLL
-#define UNROLL
-#endif
-
 /* The plan on booleans:
  *
  * The external interface uses cryptonite_decaf_bool_t, but this might be a different

--- a/cbits/decaf/p448/f_generic.c
+++ b/cbits/decaf/p448/f_generic.c
@@ -32,7 +32,7 @@ void cryptonite_gf_serialize (uint8_t serial[SER_BYTES], const gf x, int with_hi
     
     unsigned int j=0, fill=0;
     dword_t buffer = 0;
-    UNROLL for (unsigned int i=0; i<(with_hibit ? X_SER_BYTES : SER_BYTES); i++) {
+    for (unsigned int i=0; i<(with_hibit ? X_SER_BYTES : SER_BYTES); i++) {
         if (fill < 8 && j < NLIMBS) {
             buffer |= ((dword_t)red->limb[LIMBPERM(j)]) << fill;
             fill += LIMB_PLACE_VALUE(LIMBPERM(j));
@@ -57,8 +57,8 @@ mask_t cryptonite_gf_deserialize (gf x, const uint8_t serial[SER_BYTES], int wit
     unsigned int j=0, fill=0;
     dword_t buffer = 0;
     dsword_t scarry = 0;
-    UNROLL for (unsigned int i=0; i<NLIMBS; i++) {
-        UNROLL while (fill < LIMB_PLACE_VALUE(LIMBPERM(i)) && j < (with_hibit ? X_SER_BYTES : SER_BYTES)) {
+    for (unsigned int i=0; i<NLIMBS; i++) {
+        while (fill < LIMB_PLACE_VALUE(LIMBPERM(i)) && j < (with_hibit ? X_SER_BYTES : SER_BYTES)) {
             buffer |= ((dword_t)serial[j]) << fill;
             fill += 8;
             j++;


### PR DESCRIPTION
When compiling cryptonite on macOS Big Sur with an M1 Mac (Apple clang version 12.0.5) I get errors such as this:

```
cbits/decaf/p448/f_generic.c:56:8: error:
     warning: loop not unrolled: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   |
56 | mask_t cryptonite_gf_deserialize (gf x, const uint8_t serial[SER_BYTES], int with_hibit) {
   |        ^

cbits/decaf/p448/f_field.h:54:38: error:
     note: expanded from macro 'cryptonite_gf_deserialize'
   |
54 | #define cryptonite_gf_deserialize    cryptonite_gf_448_deserialize
   |                                      ^
#define cryptonite_gf_deserialize    cryptonite_gf_448_deserialize
```

Looking at the definition of the UNROLL macro it seems that it's only defined for clang:

```
#ifdef __clang__
#if 100*__clang_major__ + __clang_minor__ > 305
#define UNROLL _Pragma("clang loop unroll(full)")
#endif
#endif

#ifndef UNROLL
#define UNROLL
#endif
```

If it never worked on GCC anyway and doesn't work with clang >= 12 it probably doesn't improve performance so I removed the UNROLL macro in the decaf code. Another option would be to use the `-Wpass-failed=transform-warning` compiler flag as suggested by the error message.