### PR TITLE
Add optional MTL support

### DIFF
--- a/Crypto/Random/Types.hs
+++ b/Crypto/Random/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP, FlexibleInstances, UndecidableInstances #-}
 -- |
 -- Module      : Crypto.Random.Types
 -- License     : BSD-style
@@ -13,6 +14,10 @@ module Crypto.Random.Types
     , withDRG
     ) where
 
+#ifdef WITH_MTL_SUPPORT
+import Control.Monad.Trans
+#endif
+
 import Crypto.Random.Entropy
 import Crypto.Internal.ByteArray
 
@@ -27,6 +32,15 @@ class DRG gen where
 
 instance MonadRandom IO where
     getRandomBytes = getEntropy
+
+#ifdef WITH_MTL_SUPPORT
+instance {-# OVERLAPPABLE #-}
+    ( MonadTrans t
+    , MonadRandom m
+    , Monad (t m)
+    ) => MonadRandom (t m) where
+    getRandomBytes = lift . getRandomBytes
+#endif
 
 -- | A simple Monad class very similar to a State Monad
 -- with the state being a DRG.

--- a/cryptonite.cabal
+++ b/cryptonite.cabal
@@ -94,6 +94,11 @@ Flag support_deepseq
   Default:           True
   Manual:            True
 
+Flag support_mtl
+  Description:       define instance for MonadRandom via MTL transformers
+  Default:           False
+  Manual:            True
+
 Flag old_toolchain_inliner
   Description:       use -fgnu89-inline to workaround an old compiler / linker / glibc issue.
   Default:           False
@@ -395,6 +400,9 @@ Library
   if flag(support_deepseq)
     CPP-options:     -DWITH_DEEPSEQ_SUPPORT
     Build-depends:   deepseq
+  if flag(support_mtl)
+    CPP-options:     -DWITH_MTL_SUPPORT
+    Build-depends:   mtl
   if flag(check_alignment)
     cc-options:     -DWITH_ASSERT_ALIGNMENT
   if flag(use_target_attributes)


### PR DESCRIPTION
Ease usage of `MonadRandom` in monad transformer stacks.

Projects using MTL will benefit from being able to automatically derive `MonadRandom` instance over their custom monad transformers. 

Added new cabal flag `support_mtl` (default `false`) so users that are not interested in MTL wouldn't have to suffer from extra dependency.