### PR TITLE
Revert "Compilation warnings on OpenBSD"

### DIFF
--- a/cbits/decaf/include/decaf/point_448.h
+++ b/cbits/decaf/include/decaf/point_448.h
@@ -34,7 +34,7 @@ extern "C" {
 /** @brief Galois field element internal structure */
 typedef struct cryptonite_gf_448_s {
     cryptonite_decaf_word_t limb[512/CRYPTONITE_DECAF_WORD_BITS];
-} __attribute__((aligned(16))) cryptonite_gf_448_s, cryptonite_gf_448_t[1];
+} __attribute__((aligned(32))) cryptonite_gf_448_s, cryptonite_gf_448_t[1];
 #endif /* __CRYPTONITE_DECAF_448_GF_DEFINED__ */
 /** @endcond */
 

--- a/cbits/decaf/p448/f_field.h
+++ b/cbits/decaf/p448/f_field.h
@@ -27,7 +27,7 @@
 #define SER_BYTES 56
 typedef struct cryptonite_gf_448_s {
     word_t limb[NLIMBS];
-} __attribute__((aligned(16))) cryptonite_gf_448_s, cryptonite_gf_448_t[1];
+} __attribute__((aligned(32))) cryptonite_gf_448_s, cryptonite_gf_448_t[1];
 
 #define GF_LIT_LIMB_BITS  56
 #define GF_BITS           448

--- a/cbits/decaf/tools/generate.sh
+++ b/cbits/decaf/tools/generate.sh
@@ -22,11 +22,6 @@
 # * code related to SHAKE is replaced by cryptonite code, referenced from
 #   a custom shake.h.  As a consequence, portable_endian.h is not needed.
 #
-# * aligned(32) attributes used for stack alignment are replaced by
-#   aligned(16).  This removes warnings on OpenBSD with GCC 4.2.1, and makes
-#   sure we get at least 16-byte alignment.  32-byte alignment is necessary
-#   only for AVX2 and arch_x86_64, which we don't have.
-#
 # * visibility("hidden") attributes are removed, as this is not supported
 #   on Windows/MinGW, and we have name mangling instead
 #
@@ -49,19 +44,10 @@ fi
 
 convert() {
   local FILE_NAME="`basename "$1"`"
-  local REPL
-
-  if [ "$FILE_NAME" = word.h ]; then
-    REPL='__attribute__((aligned(32)))'
-  else
-    REPL='__attribute__((aligned(16)))'
-  fi
-
   sed <"$1" >"$2/$FILE_NAME" \
     -e 's/ __attribute((visibility("hidden")))//g' \
     -e 's/ __attribute__((visibility("hidden")))//g' \
     -e 's/ __attribute__ ((visibility ("hidden")))//g' \
-    -e "s/__attribute__((aligned(32)))/$REPL/g" \
     -e 's/decaf_/cryptonite_decaf_/g' \
     -e 's/DECAF_/CRYPTONITE_DECAF_/g' \
     -e 's/gf_/cryptonite_gf_/g' \


### PR DESCRIPTION
This reverts commit 8be985640270695522700375cfb468c1b226dc3e.

The commit breaks compilation with AVX, more specifically --ghc-option=-optc-march=znver3