### PR TITLE
ignoring exceptons from hClose to read the next entropy

### DIFF
--- a/Crypto/Random/Entropy/Unix.hs
+++ b/Crypto/Random/Entropy/Unix.hs
@@ -61,7 +61,7 @@ withDev filepath f = openDev filepath >>= \h ->
         Just fd -> f fd `E.finally` closeDev fd
 
 closeDev :: H -> IO ()
-closeDev h = hClose h
+closeDev h = hClose h `E.catch` \(_ :: IOException) -> return ()
 
 gatherDevEntropy :: H -> Ptr Word8 -> Int -> IO Int
 gatherDevEntropy h ptr sz =


### PR DESCRIPTION
The following error occurs when "tls" used heavily:

```
   uncaught exception: IOException of type NoSuchThing
       /dev/random: hClose: does not exist (No such file or directory)
```

To read "/dev/urandom" next, I think we need to ignore exceptions from hClose.

I don't understand why "close(2)" returns ENOENT (aka NoSuchThing in Haskell).